### PR TITLE
Updates to invite users to team modal window

### DIFF
--- a/app/assets/javascripts/users/settings/organizations/add_user_modal.js
+++ b/app/assets/javascripts/users/settings/organizations/add_user_modal.js
@@ -55,6 +55,7 @@ inviteExistingCollapsible
 .on("shown.bs.collapse", function() {
   // Focus input when collapsible is shown
   inviteExistingQuery.focus();
+  invitingExisting = true;
 });
 
 inviteNewCollapsible

--- a/app/views/users/settings/organizations/_destroy_user_organization_modal_body.html.erb
+++ b/app/views/users/settings/organizations/_destroy_user_organization_modal_body.html.erb
@@ -1,13 +1,15 @@
 <%= bootstrap_form_for user_organization, url: destroy_user_organization_path(user_organization, format: :json), remote: :true, method: :delete, data: { id: "destroy-user-organization-form" } do |f| %>
   <p><%= t("users.settings.organizations.edit.destroy_uo_message", user: user_organization.user.full_name, org: user_organization.organization.name) %></p>
-  <div class="alert alert-danger" role="alert">
-    <span class="glyphicon glyphicon-exclamation-sign"></span>
-    &nbsp;
-    <%= t("users.settings.organizations.edit.destroy_uo_alert_heading") %>
-    <ul>
-      <li><%= t("users.settings.organizations.edit.destroy_uo_alert_line_1") %></li>
-      <li><%= t("users.settings.organizations.edit.destroy_uo_alert_line_2").html_safe %></li>
-      <li><%= t("users.settings.organizations.edit.destroy_uo_alert_line_3") %></li>
-    </ul>
-  </div>
+  <% if user_organization.user.confirmed? %>
+    <div class="alert alert-danger" role="alert">
+      <span class="glyphicon glyphicon-exclamation-sign"></span>
+      &nbsp;
+      <%= t("users.settings.organizations.edit.destroy_uo_alert_heading") %>
+      <ul>
+        <li><%= t("users.settings.organizations.edit.destroy_uo_alert_line_1") %></li>
+        <li><%= t("users.settings.organizations.edit.destroy_uo_alert_line_2").html_safe %></li>
+        <li><%= t("users.settings.organizations.edit.destroy_uo_alert_line_3") %></li>
+      </ul>
+    </div>
+  <% end %>
 <% end %>


### PR DESCRIPTION
This PR does the following:
* Don't show the "everything belonging to the user will be reassigned onto you" alert when removing a Pending user (=user that hasn't confirmed his email yet) from the Team.
* Fix a bug when you first invited a new user, was notified that such a user exists (email), and then wanted to invite this user as an existing user (without closing the modal window).

https://biosistemika.atlassian.net/browse/SCI-228