### PR TITLE
Fixed: Comments in results have no error message if the text exceeds 1000 characters

### DIFF
--- a/app/controllers/result_comments_controller.rb
+++ b/app/controllers/result_comments_controller.rb
@@ -86,7 +86,7 @@ class ResultCommentsController < ApplicationController
         format.html { render :new }
         format.json {
           render json: {
-            errors: @comment.errors
+            errors: @comment.errors.to_hash(true)
           }
         }
       end

--- a/app/views/result_comments/_index.html.erb
+++ b/app/views/result_comments/_index.html.erb
@@ -19,7 +19,7 @@
     <li>
       <hr>
       <%= bootstrap_form_for :comment, url: { format: :json }, method: :post, remote: true do |f| %>
-        <%= f.text_field :message, hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+", onclick: "processResult(event, ResultTypeEnum.COMMENT, false);"), help: '.' %>
+        <%= f.text_field :message, hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+"), help: '.' %>
       <% end %>
     </li>
   </ul>


### PR DESCRIPTION
ISSUE
Comments in results have no error message if the text exceeds 1000 characters.

STEPS TO REPRODUCE
go to results and write a comment longer then 1000 characters

EXPECTED RESULT
Error message should be displayed.