### PR TITLE
URL presigning is now used only when using S3 file uploading (caused …

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -48,7 +48,7 @@ class AssetsController < ApplicationController
 
   def preview
     if @asset.is_image?
-      redirect_to @asset.presigned_url(:medium), status: 307
+      redirect_to @asset.url(:medium), status: 307
     else
       render_400
     end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -81,7 +81,7 @@ end
 def report_image_asset_url(asset)
   prefix = (ENV["PAPERCLIP_STORAGE"].present? && ENV["MAIL_SERVER_URL"].present? && ENV["PAPERCLIP_STORAGE"] == "filesystem") ? ENV["MAIL_SERVER_URL"] : ""
   prefix = (!prefix.empty? && !prefix.include?("http://") && !prefix.include?("https://")) ? "http://#{prefix}" : prefix
-  url = prefix + asset.presigned_url(:medium, time: 86_400)
+  url = prefix + asset.url(:medium, timeout: 86_400)
   image_tag(url)
 end
 

--- a/app/utilities/protocols_exporter.rb
+++ b/app/utilities/protocols_exporter.rb
@@ -53,11 +53,7 @@ module ProtocolsExporter
         asset_json["fileType"] = asset_json.delete("file_content_type")
 
         # Retrieve file contents
-        if asset.file.is_stored_on_s3?
-          file = open(asset.presigned_url, "rb")
-        else
-          file = File.open(asset.file.path, "rb")
-        end
+        file = asset.open
         asset_json["bytes"] = Base64.encode64(file.read)
         file.close
 


### PR DESCRIPTION
…error for local uploading) [fixes SCI-447], along with some refactoring.