### PR TITLE
Remove invitation_to_organization email

### DIFF
--- a/app/controllers/users/settings_controller.rb
+++ b/app/controllers/users/settings_controller.rb
@@ -212,9 +212,6 @@ class Users::SettingsController < ApplicationController
       user: @new_user_org.user,
       organization: @new_user_org.organization
       ).exists? && @new_user_org.save
-      AppMailer.delay.invitation_to_organization(@new_user_org.user,
-                                                 @user_organization.user,
-                                                 @new_user_org.organization)
 
       generate_notification(@user_organization.user,
                             @new_user_org.user,

--- a/app/mailers/app_mailer.rb
+++ b/app/mailers/app_mailer.rb
@@ -5,14 +5,6 @@ class AppMailer < Devise::Mailer
   default from: ENV["MAIL_FROM"]
   default reply: ENV["MAIL_REPLYTO"]
 
-  def invitation_to_organization(user, added_by, organization, opts = {})
-    @user = user
-    @added_by = added_by
-    @org = organization
-    headers = { to: @user.email, subject: (I18n.t('mailer.invitation_to_organization.subject')) }.merge(opts)
-    mail(headers)
-  end
-
   def notification(user, notification)
     @user = user
     @notification = notification

--- a/app/views/users/mailer/invitation_to_organization.html.erb
+++ b/app/views/users/mailer/invitation_to_organization.html.erb
@@ -1,1 +1,0 @@
-<p><%=t "mailer.invitation_to_organization.text", addedBy: @added_by.name, organization: @org.name %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1449,11 +1449,6 @@ en:
       head_title: "Edit protocol"
     no_keywords: "No keywords"
 
-  mailer:
-    invitation_to_organization:
-      subject: "You have been invited to team"
-      text: "User %{addedBy} has added you to team %{organization}."
-
   time:
     formats:
       full: "%d.%m.%Y %H:%M"

--- a/test/mailers/previews/app_mailer_preview.rb
+++ b/test/mailers/previews/app_mailer_preview.rb
@@ -15,10 +15,6 @@ class AppMailerPreview < ActionMailer::Preview
     AppMailer.invitation_instructions(fake_user, "faketoken", {})
   end
 
-  def invitation_to_organization
-    AppMailer.invitation_to_organization(fake_user, fake_user_2, fake_org, {})
-  end
-
   private
 
   def fake_user
@@ -29,23 +25,6 @@ class AppMailerPreview < ActionMailer::Preview
       created_at: Time.now,
       updated_at: Time.now,
       confirmed_at: Time.now
-    )
-  end
-
-  def fake_user_2
-    User.new(
-      full_name: "Bob Dylan",
-      initials: "BD",
-      email: "bob.dylan@gmail.com",
-      created_at: Time.now,
-      updated_at: Time.now,
-      confirmed_at: Time.now
-    )
-  end
-
-  def fake_org
-    Organization.new(
-      name: "Greatest musicians of all time"
     )
   end
 end


### PR DESCRIPTION
This email is no longer needed, because if user enables assignment notifications, he/she will already receive an email whenever he/she is added to a new organization/team (via notifications email).