### PR TITLE
Tab selector

### DIFF
--- a/app/assets/javascripts/secondary_navigation.js
+++ b/app/assets/javascripts/secondary_navigation.js
@@ -28,7 +28,7 @@
         url: ajaxUrl,
         type: 'POST',
         dataType: 'json',
-        data: {tab: tab, },
+        data: {tab: tab},
         success: function(data) {
           // Reload page
           location.reload();

--- a/app/assets/javascripts/secondary_navigation.js
+++ b/app/assets/javascripts/secondary_navigation.js
@@ -1,0 +1,49 @@
+(function() {
+  'use strict';
+
+  function initializeModuleTabSelector() {
+    var parent = $('[data-role=module-tab-selector]');
+    var ajaxUrl = parent.attr('data-url');
+
+    // Disable checkboxes if neccesary
+    parent.find('li.disabled input[type=checkbox]').attr('disabled');
+
+    // Prevent clicks on checkboxes in dropdown
+    parent.find('input[type=checkbox]').on('click', function(ev) {
+      this.checked = !this.checked;
+      ev.preventDefault();
+      return false;
+    });
+
+    // Toggle tab functionality
+    parent.find('li:not(.disabled) [data-tab]').on('click', function() {
+      var $this = $(this);
+      var tab = $this.attr('data-tab');
+
+      // Enable spinner on dropdown
+      animateSpinner(parent);
+
+      // Do the AJAX call onto server
+      $.ajax({
+        url: ajaxUrl,
+        type: 'POST',
+        dataType: 'json',
+        data: {tab: tab, },
+        success: function(data) {
+          // Reload page
+          location.reload();
+        },
+        error: function(data) {
+          // Disable spinner
+          animateSpinner(parent, false);
+        }
+      });
+    });
+  }
+
+  // Only initialize module tab selector if it's actually
+  // present on the page
+  if ($('[data-role=module-tab-selector]').length) {
+    initializeModuleTabSelector();
+  }
+})();

--- a/app/assets/javascripts/secondary_navigation.js
+++ b/app/assets/javascripts/secondary_navigation.js
@@ -21,7 +21,7 @@
       var tab = $this.attr('data-tab');
 
       // Enable spinner on dropdown
-      animateSpinner(parent);
+      animateSpinner();
 
       // Do the AJAX call onto server
       $.ajax({
@@ -35,7 +35,7 @@
         },
         error: function(data) {
           // Disable spinner
-          animateSpinner(parent, false);
+          animateSpinner(null, false);
         }
       });
     });

--- a/app/assets/stylesheets/themes/scinote.scss
+++ b/app/assets/stylesheets/themes/scinote.scss
@@ -1399,3 +1399,13 @@ html.turbolinks-progress-bar::before {
     display: inline;
   }
 }
+
+.dropdown-menu-task-tab-selector {
+  li {
+    text-transform: none;
+
+    a {
+      padding-left: 10px;
+    }
+  }
+}

--- a/app/assets/stylesheets/themes/scinote.scss
+++ b/app/assets/stylesheets/themes/scinote.scss
@@ -1400,7 +1400,7 @@ html.turbolinks-progress-bar::before {
   }
 }
 
-.dropdown-menu-task-tab-selector {
+.dropdown-menu-module-tab-selector {
   li {
     text-transform: none;
 

--- a/app/controllers/my_modules_controller.rb
+++ b/app/controllers/my_modules_controller.rb
@@ -7,7 +7,8 @@ class MyModulesController < ApplicationController
     :samples, :activities, :activities_tab,
     :assign_samples, :unassign_samples,
     :delete_samples,
-    :samples_index, :archive, :toggle_tab]
+    :samples_index, :archive, :toggle_tab
+  ]
   before_action :load_markdown, only: [ :results ]
   before_action :load_vars_nested, only: [:new, :create]
   before_action :check_edit_permissions, only: [

--- a/app/controllers/my_modules_controller.rb
+++ b/app/controllers/my_modules_controller.rb
@@ -308,7 +308,7 @@ class MyModulesController < ApplicationController
   end
 
   def toggle_tab
-    toggled = @my_module.toggle_tab(params['tab'])
+    toggled = @my_module.toggle_tab(params[:tab])
 
     respond_to do |format|
       format.html
@@ -402,15 +402,16 @@ class MyModulesController < ApplicationController
   end
 
   def check_toggle_tab_permissions
-    render_403 if !can_edit_module_tabs(@my_module) || params['tab'].blank?
+    render_403 if !can_edit_module_tabs(@my_module) || params[:tab].blank?
   end
 
   def check_if_tab_is_shown
-    redirect_to show unless @my_module.shown_tabs.include?(action_name)
+    redirect_to(action: :show) && return unless
+      @my_module.shown_tabs.include?(action_name)
   end
 
   def my_module_params
     params.require(:my_module).permit(:name, :description, :due_date,
-      :archived)
+                                      :archived)
   end
 end

--- a/app/controllers/my_modules_controller.rb
+++ b/app/controllers/my_modules_controller.rb
@@ -23,6 +23,8 @@ class MyModulesController < ApplicationController
   before_action :check_assign_samples_permissions, only: [:assign_samples]
   before_action :check_unassign_samples_permissions, only: [:unassign_samples]
   before_action :check_toggle_tab_permissions, only: [:toggle_tab]
+  before_action :check_if_tab_is_shown,
+                only: [:protocols, :results, :activities, :samples]
 
   layout "fluid"
 
@@ -332,11 +334,11 @@ class MyModulesController < ApplicationController
         @my_module.shown_tabs << 'results'
         @my_module.save
       end
-    when 'activity'
-      if @my_module.shown_tabs.include?('activity')
-        @my_module.shown_tabs.delete('activity')
+    when 'activities'
+      if @my_module.shown_tabs.include?('activities')
+        @my_module.shown_tabs.delete('activities')
       else
-        @my_module.shown_tabs << 'activity'
+        @my_module.shown_tabs << 'activities'
       end
       @my_module.save
     when 'samples'
@@ -446,6 +448,10 @@ class MyModulesController < ApplicationController
 
   def check_toggle_tab_permissions
     render_403 if !can_edit_module_tabs(@my_module) || params['tab'].blank?
+  end
+
+  def check_if_tab_is_shown
+    redirect_to show unless @my_module.shown_tabs.include?(action_name)
   end
 
   def my_module_params

--- a/app/controllers/my_modules_controller.rb
+++ b/app/controllers/my_modules_controller.rb
@@ -307,53 +307,7 @@ class MyModulesController < ApplicationController
   end
 
   def toggle_tab
-    toggled = true
-
-    case params['tab']
-    when 'protocols'
-      if @my_module.shown_tabs.include?('protocols')
-        if @my_module.protocols.count == 0
-          @my_module.shown_tabs.delete('protocols')
-          @my_module.save
-        else
-          toggled = false
-        end
-      else
-        @my_module.shown_tabs << 'protocols'
-        @my_module.save
-      end
-    when 'results'
-      if @my_module.shown_tabs.include?('results')
-        if @my_module.results.count == 0
-          @my_module.shown_tabs.delete('results')
-          @my_module.save
-        else
-          toggled = false
-        end
-      else
-        @my_module.shown_tabs << 'results'
-        @my_module.save
-      end
-    when 'activities'
-      if @my_module.shown_tabs.include?('activities')
-        @my_module.shown_tabs.delete('activities')
-      else
-        @my_module.shown_tabs << 'activities'
-      end
-      @my_module.save
-    when 'samples'
-      if @my_module.shown_tabs.include?('samples')
-        if @my_module.samples.count == 0
-          @my_module.shown_tabs.delete('samples')
-          @my_module.save
-        else
-          toggled = false
-        end
-      else
-        @my_module.shown_tabs << 'samples'
-        @my_module.save
-      end
-    end
+    toggled = @my_module.toggle_tab(params['tab'])
 
     respond_to do |format|
       format.html

--- a/app/helpers/my_module_tabs_helper.rb
+++ b/app/helpers/my_module_tabs_helper.rb
@@ -38,6 +38,6 @@ module MyModuleTabsHelper
 
   def my_module_tab_toggle_disabled?(my_module, tab)
     my_module.shown_tabs.include?(tab) &&
-    !my_module.send("can_uncheck_tab_#{tab}?")
+      !my_module.send("can_uncheck_tab_#{tab}?")
   end
 end

--- a/app/helpers/my_module_tabs_helper.rb
+++ b/app/helpers/my_module_tabs_helper.rb
@@ -22,9 +22,9 @@ module MyModuleTabsHelper
     res.html_safe
   end
 
-  def my_module_tab_selector_tab_li(my_module, tab, can_uncheck = true)
+  def my_module_tab_selector_tab_li(my_module, tab)
     res = <<-eos
-    <li class="#{'disabled' if my_module_tab_toggle_disabled?(my_module, tab, can_uncheck)}">
+    <li class="#{'disabled' if my_module_tab_toggle_disabled?(my_module, tab)}">
       <a href="#" data-tab="#{tab}">
         <input type="checkbox" #{'checked="checked"' if my_module.shown_tabs.include?(tab)}>
         #{t('nav2.modules.' + tab)}
@@ -36,7 +36,8 @@ module MyModuleTabsHelper
 
   private
 
-  def my_module_tab_toggle_disabled?(my_module, tab, can_uncheck)
-    my_module.shown_tabs.include?(tab) && !can_uncheck
+  def my_module_tab_toggle_disabled?(my_module, tab)
+    my_module.shown_tabs.include?(tab) &&
+    !my_module.send("can_uncheck_tab_#{tab}?")
   end
 end

--- a/app/helpers/my_module_tabs_helper.rb
+++ b/app/helpers/my_module_tabs_helper.rb
@@ -1,0 +1,35 @@
+module MyModuleTabsHelper
+  # Options can contain the following elements:
+  # - id - HTML id of the <li> element
+  def my_module_tab_li(my_module, tab, href, active, glyphicon, opts = {})
+    return '' unless my_module.shown_tabs.include?(tab)
+
+    res = <<-eos
+    <li id="#{opts['id']}" class="#{'active' if active}">
+      <a href="#{href}" title="#{t('nav2.modules.' + tab)}">
+        <span class="hidden-sm hidden-md">#{t('nav2.modules.' + tab)}</span>
+        <span class="hidden-xs hidden-lg glyphicon #{glyphicon}"></span>
+      </a>
+    </li>
+    eos
+    res.html_safe
+  end
+
+  def my_module_tab_selector_tab_li(my_module, tab, can_uncheck = true)
+    res = <<-eos
+    <li class="#{'disabled' if my_module_tab_toggle_disabled?(my_module, tab, can_uncheck)}">
+      <a href="#" data-tab="#{tab}">
+        <input type="checkbox" #{'checked="checked"' if my_module.shown_tabs.include?(tab)}>
+        #{t('nav2.modules.' + tab)}
+      </a>
+    </li>
+    eos
+    res.html_safe
+  end
+
+  private
+
+  def my_module_tab_toggle_disabled?(my_module, tab, can_uncheck)
+    my_module.shown_tabs.include?(tab) && !can_uncheck
+  end
+end

--- a/app/helpers/my_module_tabs_helper.rb
+++ b/app/helpers/my_module_tabs_helper.rb
@@ -1,13 +1,20 @@
 module MyModuleTabsHelper
   # Options can contain the following elements:
   # - id - HTML id of the <li> element
-  def my_module_tab_li(my_module, tab, href, active, glyphicon, opts = {})
+  # - href - If route to the tab is different than
+  #          <tab>_my_module_path(my_module)
+  def my_module_tab_li(my_module, tab, active, glyphicon, opts = {})
     return '' unless my_module.shown_tabs.include?(tab)
+
+    title = t("nav2.modules.#{tab}")
+    if opts['href'].blank?
+      opts['href'] = send("#{tab}_my_module_path", my_module)
+    end
 
     res = <<-eos
     <li id="#{opts['id']}" class="#{'active' if active}">
-      <a href="#{href}" title="#{t('nav2.modules.' + tab)}">
-        <span class="hidden-sm hidden-md">#{t('nav2.modules.' + tab)}</span>
+      <a href="#{opts['href']}" title="#{title}">
+        <span class="hidden-sm hidden-md">#{title}</span>
         <span class="hidden-xs hidden-lg glyphicon #{glyphicon}"></span>
       </a>
     </li>

--- a/app/helpers/my_module_tabs_helper.rb
+++ b/app/helpers/my_module_tabs_helper.rb
@@ -6,7 +6,7 @@ module MyModuleTabsHelper
   def my_module_tab_li(my_module, tab, active, glyphicon, opts = {})
     return '' unless my_module.shown_tabs.include?(tab)
 
-    title = t("nav2.modules.#{tab}")
+    title = sanitize(t("nav2.modules.#{tab}"))
     if opts['href'].blank?
       opts['href'] = send("#{tab}_my_module_path", my_module)
     end
@@ -15,7 +15,7 @@ module MyModuleTabsHelper
     <li id="#{opts['id']}" class="#{'active' if active}">
       <a href="#{opts['href']}" title="#{title}">
         <span class="hidden-sm hidden-md">#{title}</span>
-        <span class="hidden-xs hidden-lg glyphicon #{glyphicon}"></span>
+        <span class="hidden-xs hidden-lg glyphicon #{sanitize(glyphicon)}"></span>
       </a>
     </li>
     eos
@@ -27,7 +27,7 @@ module MyModuleTabsHelper
     <li class="#{'disabled' if my_module_tab_toggle_disabled?(my_module, tab)}">
       <a href="#" data-tab="#{tab}">
         <input type="checkbox" #{'checked="checked"' if my_module.shown_tabs.include?(tab)}>
-        #{t('nav2.modules.' + tab)}
+        #{sanitize(t('nav2.modules.' + tab))}
       </a>
     </li>
     eos

--- a/app/helpers/permission_helper.rb
+++ b/app/helpers/permission_helper.rb
@@ -91,6 +91,7 @@ module PermissionHelper
       :can_edit_tags_for_module,
       :can_add_tag_to_module,
       :can_remove_tag_from_module,
+      :can_edit_module_tabs,
       :can_view_module_info,
       :can_view_module_users,
       :can_edit_users_on_module,
@@ -457,6 +458,10 @@ module PermissionHelper
   end
 
   def can_remove_tag_from_module(my_module)
+    is_user_or_higher_of_project(my_module.experiment.project)
+  end
+
+  def can_edit_module_tabs(my_module)
     is_user_or_higher_of_project(my_module.experiment.project)
   end
 

--- a/app/helpers/secondary_navigation_helper.rb
+++ b/app/helpers/secondary_navigation_helper.rb
@@ -1,58 +1,49 @@
 module SecondaryNavigationHelper
-
-  def is_project_info?
+  def project_info?
     action_name == 'show'
   end
 
-  def is_project_show?
+  def project_show?
     action_name == 'show'
   end
 
-  def is_project_samples?
+  def project_samples?
     action_name == 'samples'
   end
 
-  def is_project_reports?
-    controller_name == 'reports' && action_name == 'index'
-  end
-
-  def is_project_archive?
+  def project_archive?
     action_name == 'experiment_archive'
   end
 
-  def is_experiment_canvas?
+  def experiment_canvas?
     action_name == 'canvas'
   end
 
-  def is_experiment_archive?
+  def experiment_archive?
     action_name == 'module_archive'
   end
 
-  def is_experiment_samples?
+  def experiment_samples?
     action_name == 'samples'
   end
 
-  def is_module_info?
+  def module_overview?
     action_name == 'show'
   end
 
-  def is_module_protocols?
+  def module_protocols?
     action_name == 'protocols'
   end
 
-  def is_module_results?
+  def module_results?
     action_name == 'results'
   end
 
-  def is_module_activities?
+  def module_activities?
     action_name == 'activities'
   end
 
-  def is_module_samples?
+  def module_samples?
     action_name == 'samples'
-  end
-
-  def is_module_archive?
-    action_name == 'archive'
   end
 end

--- a/app/helpers/sidebar_helper.rb
+++ b/app/helpers/sidebar_helper.rb
@@ -32,16 +32,18 @@ module SidebarHelper
 
   def module_action_to_link_to(my_module)
     case action_name
+    when 'protocols'
+      return protocols_my_module_path(my_module)
     when 'results'
-      return results_my_module_url(my_module)
+      return results_my_module_path(my_module)
     when 'activities'
-      return activities_my_module_url(my_module)
+      return activities_my_module_path(my_module)
     when 'samples'
-      return samples_my_module_url(my_module)
+      return samples_my_module_path(my_module)
     when 'archive', 'module_archive', 'experiment_archive'
-      return archive_my_module_url(my_module)
+      return archive_my_module_path(my_module)
     else
-      return protocols_my_module_url(my_module)
+      return my_module_path(my_module)
     end
   end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -71,7 +71,7 @@ class Activity < ActiveRecord::Base
                           .application
                           .routes
                           .url_helpers
-                          .protocols_my_module_path(my_module)}'>
+                          .my_module_path(my_module)}'>
               #{my_module.name}</a>" if my_module
 
     notification = Notification.create(

--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -11,6 +11,7 @@ class MyModule < ActiveRecord::Base
   validates :x, :y, :workflow_order, presence: true
   validates :experiment, presence: true
   validates :my_module_group, presence: true, if: "!my_module_group_id.nil?"
+  validates :shown_tabs, presence: true
 
   belongs_to :created_by, foreign_key: 'created_by_id', class_name: 'User'
   belongs_to :last_modified_by, foreign_key: 'last_modified_by_id', class_name: 'User'

--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -386,7 +386,8 @@ class MyModule < ActiveRecord::Base
   end
 
   def can_uncheck_tab_protocols?
-    protocols.count.zero?
+    protocols.count.zero? ||
+      protocol.steps.count.zero?
   end
 
   def can_uncheck_tab_results?

--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -356,6 +356,51 @@ class MyModule < ActiveRecord::Base
     { x: 0, y: positions.last[1] + HEIGHT }
   end
 
+  def toggle_tab(tab)
+    toggled = true
+
+    begin
+      # This is done in advance so even if enabling tabs
+      # (where can_uncheck doesn't need to be called),
+      # it's called anyway just to check if the tab
+      # parameter is legal (e.g. it's not an evil,
+      # injected value)
+      can_uncheck = send("can_uncheck_tab_#{tab}?")
+
+      if shown_tabs.include?(tab)
+        if can_uncheck
+          shown_tabs.delete(tab)
+          save
+        else
+          toggled = false
+        end
+      else
+        shown_tabs << tab
+        save
+      end
+    rescue StandardError
+      toggled = false
+    end
+
+    toggled
+  end
+
+  def can_uncheck_tab_protocols?
+    protocols.count == 0
+  end
+
+  def can_uncheck_tab_results?
+    results.count == 0
+  end
+
+  def can_uncheck_tab_activities?
+    true
+  end
+
+  def can_uncheck_tab_samples?
+    samples.count == 0
+  end
+
   private
 
   def create_blank_protocol

--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -386,11 +386,11 @@ class MyModule < ActiveRecord::Base
   end
 
   def can_uncheck_tab_protocols?
-    protocols.count == 0
+    protocols.count.zero?
   end
 
   def can_uncheck_tab_results?
-    results.count == 0
+    results.count.zero?
   end
 
   def can_uncheck_tab_activities?
@@ -398,7 +398,7 @@ class MyModule < ActiveRecord::Base
   end
 
   def can_uncheck_tab_samples?
-    samples.count == 0
+    samples.count.zero?
   end
 
   private

--- a/app/views/canvas/full_zoom/_my_module.html.erb
+++ b/app/views/canvas/full_zoom/_my_module.html.erb
@@ -25,7 +25,7 @@
 
   <div class="panel-heading">
     <h3 class="panel-title">
-      <%= link_to_if can_view_module(my_module), my_module.name, protocols_my_module_path(my_module) %>
+      <%= link_to_if can_view_module(my_module), my_module.name, my_module_path(my_module) %>
     </h3>
   </div>
 

--- a/app/views/canvas/medium_zoom/_my_module.html.erb
+++ b/app/views/canvas/medium_zoom/_my_module.html.erb
@@ -24,7 +24,7 @@
 
   <div class="panel-heading">
     <h3 class="panel-title">
-      <%= link_to_if can_view_module(my_module), my_module.name, protocols_my_module_path(my_module) %>
+      <%= link_to_if can_view_module(my_module), my_module.name, my_module_path(my_module) %>
     </h3>
   </div>
 </div>

--- a/app/views/canvas/small_zoom/_my_module.html.erb
+++ b/app/views/canvas/small_zoom/_my_module.html.erb
@@ -9,6 +9,6 @@
   data-module-y="<%= my_module.y %>"
   data-module-conns="<%= construct_module_connections(my_module) %>">
   <span>
-    <%= link_to_if can_view_module(my_module), my_module.name[0], protocols_my_module_path(my_module) %>
+    <%= link_to_if can_view_module(my_module), my_module.name[0], my_module_path(my_module) %>
   </span>
 </div>

--- a/app/views/my_modules/show.html.erb
+++ b/app/views/my_modules/show.html.erb
@@ -1,11 +1,4 @@
-<% provide(:head_title, raw(t("my_modules.show.head_title", project: @my_module.project.name, module: @my_module.name))) %>
+<% provide(:head_title, raw(t("my_modules.show.head_title", project: @my_module.experiment.project.name, module: @my_module.name))) %>
 <%= render partial: "shared/sidebar" %>
 <%= render partial: "shared/secondary_navigation" %>
 
-<% unless @my_module.archived %>
-<%= form_for @my_module, method: :patch, format: :html do |f| %>
-  <%= f.hidden_field :archived, value: true %>
-  <%= button_tag t('my_modules.show.archive_action'), class: 'btn btn-danger',
-    data: { confirm: t('my_modules.show.archive_confirm_text') } %>
-<% end %>
-<% end %>

--- a/app/views/shared/_secondary_navigation.html.erb
+++ b/app/views/shared/_secondary_navigation.html.erb
@@ -117,81 +117,74 @@
       <% elsif module_page? %>
         <ul class="nav navbar-nav navbar-right" style="vertical-align: bottom">
           <li id="overview-nav-tab" class="<%= "active" if module_overview? %>">
-            <a href="<%= my_module_path(@my_module) %>" title="">
-              <span class="hidden-sm hidden-md"><%=t "nav2.modules.overview" %></span>
+            <a href="<%= my_module_path(@my_module) %>" title="<%= t('nav2.modules.overview') %>">
+              <span class="hidden-sm hidden-md"><%= t('nav2.modules.overview') %></span>
               <span class="hidden-xs hidden-lg glyphicon glyphicon-blackboard"></span>
             </a>
           </li>
-          <% if can_view_module_protocols(@my_module) && @my_module.shown_tabs.include?('protocols') %>
-            <li id="steps-nav-tab" class="<%= "active" if module_protocols? %>">
-              <a href="<%= protocols_my_module_url(@my_module) %>" title="<%=t "nav2.modules.steps" %>">
-                <span class="hidden-sm hidden-md"><%=t "nav2.modules.steps" %></span>
-                <span class="hidden-xs hidden-lg glyphicon glyphicon-circle-arrow-right"></span>
-              </a>
-            </li>
+          <% if can_view_module_protocols(@my_module) %>
+            <%= my_module_tab_li(
+                  @my_module,
+                  'protocols',
+                  protocols_my_module_path(@my_module),
+                  module_protocols?,
+                  'glyphicon-circle-arrow-right',
+                  { id: 'steps-nav-tab' }
+                )
+            %>
           <% end %>
-          <% if can_view_results_in_module(@my_module) && @my_module.shown_tabs.include?('results') %>
-            <li id="results-nav-tab" class="<%= "active" if module_results? %>">
-              <a href="<%= results_my_module_url(@my_module) %>" title="<%=t "nav2.modules.results" %>">
-                <span class="hidden-sm hidden-md"><%=t "nav2.modules.results" %></span>
-                <span class="hidden-xs hidden-lg glyphicon glyphicon-th"></span>
-              </a>
-            </li>
+          <% if can_view_results_in_module(@my_module) %>
+            <%= my_module_tab_li(
+                  @my_module,
+                  'results',
+                  results_my_module_path(@my_module),
+                  module_results?,
+                  'glyphicon-th',
+                  { id: 'results-nav-tab' }
+                )
+            %>
           <% end %>
-          <% if can_view_module_activities(@my_module) && @my_module.shown_tabs.include?('activity') %>
-            <li id="activities-nav-tab" class="<%= "active" if module_activities? %>">
-              <a href="<%= activities_my_module_url(@my_module) %>" title="<%=t "nav2.modules.activities" %>">
-                <span class="hidden-sm hidden-md"><%=t "nav2.modules.activities" %></span>
-                <span class="hidden-xs hidden-lg glyphicon glyphicon-equalizer"></span>
-              </a>
-            </li>
+          <% if can_view_module_activities(@my_module) %>
+            <%= my_module_tab_li(
+                  @my_module,
+                  'activity',
+                  activities_my_module_path(@my_module),
+                  module_activities?,
+                  'glyphicon-equalizer',
+                  { id: 'activities-nav-tab' }
+                )
+            %>
           <% end %>
-          <% if can_view_module_samples(@my_module) && @my_module.shown_tabs.include?('samples') %>
-            <li id="module-samples-nav-tab" class="<%= "active" if module_samples? %>">
-              <a href="<%= samples_my_module_url(@my_module) %>" title="<%=t "nav2.modules.samples" %>">
-                <span class="hidden-sm hidden-md"><%=t "nav2.modules.samples" %></span>
-                <span class="hidden-xs hidden-lg glyphicon glyphicon-tint"></span>
-              </a>
-            </li>
+          <% if can_view_module_samples(@my_module) %>
+            <%= my_module_tab_li(
+                  @my_module,
+                  'samples',
+                  samples_my_module_path(@my_module),
+                  module_samples?,
+                  'glyphicon-tint',
+                  { id: 'module-samples-nav-tab' }
+                )
+            %>
           <% end %>
-            <!-- Deface hook to inject additional tabs after this one-->
-            <li data-hook="module-nav-tabs"></li>
+          <!-- Deface hook to inject additional tabs after this one-->
+          <li data-hook="module-nav-tabs"></li>
           <% if can_edit_module_tabs(@my_module) %>
             <li class="dropdown" data-role="module-tab-selector" data-url="<%= toggle_tab_my_module_path(@my_module) %>">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
                 <span class="glyphicon glyphicon-menu-down"></span>
               </a>
-              <ul class="dropdown-menu dropdown-menu-task-tab-selector" data-hook="module-tab-selector">
+              <ul class="dropdown-menu dropdown-menu-module-tab-selector">
                 <li class="disabled">
                   <a href="#">
                     <input type="checkbox" checked="checked">
                     <%= t('nav2.modules.overview') %>
                   </a>
                 </li>
-                <li class="<%= 'disabled' if (@my_module.shown_tabs.include?('protocols') && @my_module.protocols.count > 0) %>">
-                  <a href="#" data-tab="protocols">
-                    <input type="checkbox" <%= 'checked="checked"' if @my_module.shown_tabs.include?('protocols') %>>
-                    <%= t('nav2.modules.steps') %>
-                  </a>
-                </li>
-                <li class="<%= 'disabled' if (@my_module.shown_tabs.include?('results') && @my_module.results.count > 0) %>">
-                  <a href="#" data-tab="results">
-                    <input type="checkbox" <%= 'checked="checked"' if @my_module.shown_tabs.include?('results') %>>
-                    <%= t('nav2.modules.results') %>
-                  </a>
-                </li>
-                <li>
-                  <a href="#" data-tab="activity">
-                    <input type="checkbox" <%= 'checked="checked"' if @my_module.shown_tabs.include?('activity') %>>
-                    <%= t('nav2.modules.activities') %>
-                  </a>
-                </li>
-                <li class="<%= 'disabled' if (@my_module.shown_tabs.include?('samples') && @my_module.samples.count > 0) %>">
-                  <a href="#" data-tab="samples">
-                    <input type="checkbox" <%= 'checked="checked"' if @my_module.shown_tabs.include?('samples') %>>
-                    <%= t('nav2.modules.samples') %>
-                  </a>
-                </li>
+                <%= my_module_tab_selector_tab_li(@my_module, 'protocols', @my_module.protocols.count == 0) %>
+                <%= my_module_tab_selector_tab_li(@my_module, 'results', @my_module.results.count == 0) %>
+                <%= my_module_tab_selector_tab_li(@my_module, 'activity') %>
+                <%= my_module_tab_selector_tab_li(@my_module, 'samples', @my_module.samples.count == 0) %>
+                <li style="display: none;" data-hook="module-tab-selector"></li>
               </ul>
             </li>
           <% end %>

--- a/app/views/shared/_secondary_navigation.html.erb
+++ b/app/views/shared/_secondary_navigation.html.erb
@@ -176,10 +176,10 @@
                     <%= t('nav2.modules.overview') %>
                   </a>
                 </li>
-                <%= my_module_tab_selector_tab_li(@my_module, 'protocols', @my_module.protocols.count == 0) %>
-                <%= my_module_tab_selector_tab_li(@my_module, 'results', @my_module.results.count == 0) %>
+                <%= my_module_tab_selector_tab_li(@my_module, 'protocols') %>
+                <%= my_module_tab_selector_tab_li(@my_module, 'results') %>
                 <%= my_module_tab_selector_tab_li(@my_module, 'activities') %>
-                <%= my_module_tab_selector_tab_li(@my_module, 'samples', @my_module.samples.count == 0) %>
+                <%= my_module_tab_selector_tab_li(@my_module, 'samples') %>
                 <li style="display: none;" data-hook="module-tab-selector"></li>
               </ul>
             </li>

--- a/app/views/shared/_secondary_navigation.html.erb
+++ b/app/views/shared/_secondary_navigation.html.erb
@@ -66,10 +66,10 @@
     <div class="collapse navbar-collapse" id="secondary-menu">
 
       <!-- True secondary navigation (buttons on the right side) -->
-      <ul class="nav navbar-nav navbar-right" style="vertical-align: bottom">
-        <% if project_page? %>
+      <% if project_page? %>
+        <ul class="nav navbar-nav navbar-right" style="vertical-align: bottom" data-hook="project-nav-tabs">
           <% if can_view_project(@project) then %>
-            <li id="canvas-nav-tab" class="<%= "active" if is_project_show? %>">
+            <li id="canvas-nav-tab" class="<%= "active" if project_show? %>">
               <a href="<%= project_url(@project) %>" title="<%=t "nav2.projects.show" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.projects.show" %></span>
                 <span class="hidden-xs hidden-lg glyphicon glyphicon-blackboard"></span>
@@ -77,30 +77,23 @@
             </li>
           <% end %>
           <% if can_view_project_samples(@project) then %>
-            <li id="project-samples-nav-tab" class="<%= "active" if is_project_samples? %>">
+            <li id="project-samples-nav-tab" class="<%= "active" if project_samples? %>">
               <a href="<%= samples_project_url(@project) %>" title="<%=t "nav2.projects.samples" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.projects.samples" %></span>
                 <span class="hidden-xs hidden-lg glyphicon glyphicon-tint"></span>
               </a>
             </li>
           <% end %>
-          <% if can_view_reports(@project) then %>
-            <li id="reports-nav-tab" class="<%= "active" if is_project_reports? %>">
-              <a href="<%= project_reports_url(@project) %>" title="<%=t "nav2.projects.reports" %>">
-                <span class="hidden-sm hidden-md"><%=t "nav2.projects.reports" %></span>
-                <span class="hidden-xs hidden-lg glyphicon glyphicon-list-alt"></span>
-              </a>
-            </li>
-          <% end %>
           <% if can_view_project_archive(@project) then %>
-            <li id="project-archive-nav-tab" class="<%= "active" if is_project_archive? %>">
+            <li id="project-archive-nav-tab" class="<%= "active" if project_archive? %>">
               <a href="<%= experiment_archive_project_url(@project) %>"><span class="glyphicon glyphicon-briefcase"></span></a>
             </li>
           <% end %>
-
-        <% elsif experiment_page? %>
+        </ul>
+      <% elsif experiment_page? %>
+        <ul class="nav navbar-nav navbar-right" style="vertical-align: bottom" data-hook="project-nav-tabs">
           <% if can_view_experiment(@experiment) then %>
-              <li id="canvas-nav-tab" class="<%= "active" if is_experiment_canvas? %>">
+              <li id="canvas-nav-tab" class="<%= "active" if experiment_canvas? %>">
                 <a href="<%= canvas_experiment_url(@experiment) %>" title="<%=t "nav2.experiments.canvas" %>">
                   <span class="hidden-sm hidden-md"><%=t "nav2.experiments.canvas" %></span>
                   <span class="hidden-xs hidden-lg glyphicon glyphicon-blackboard"></span>
@@ -108,30 +101,29 @@
               </li>
           <% end %>
           <% if can_view_experiment_samples(@experiment) then %>
-            <li id="experiment-samples-nav-tab" class="<%= "active" if is_experiment_samples? %>">
+            <li id="experiment-samples-nav-tab" class="<%= "active" if experiment_samples? %>">
               <a href="<%= samples_experiment_url(@experiment) %>" title="<%=t "nav2.projects.samples" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.projects.samples" %></span>
                 <span class="hidden-xs hidden-lg glyphicon glyphicon-tint"></span>
               </a>
             </li>
           <% end %>
-          <% if can_view_reports(@experiment.project) then %>
-              <li id="reports-nav-tab" class="<%= "active" if is_project_reports? %>">
-                <a href="<%= project_reports_url(@experiment.project) %>" title="<%=t "nav2.projects.reports" %>">
-                  <span class="hidden-sm hidden-md"><%=t "nav2.projects.reports" %></span>
-                  <span class="hidden-xs hidden-lg glyphicon glyphicon-list-alt"></span>
-                </a>
-              </li>
-          <% end %>
           <% if can_view_experiment_archive(@experiment) then %>
-              <li id="project-archive-nav-tab" class="<%= "active" if is_experiment_archive? %>">
-                <a href="<%= module_archive_experiment_url(@experiment) %>"><span class="glyphicon glyphicon-briefcase"></span></a>
-              </li>
+            <li id="project-archive-nav-tab" class="<%= "active" if experiment_archive? %>">
+              <a href="<%= module_archive_experiment_url(@experiment) %>"><span class="glyphicon glyphicon-briefcase"></span></a>
+            </li>
           <% end %>
-
-        <% elsif module_page? %>
+        </ul>
+      <% elsif module_page? %>
+        <ul class="nav navbar-nav navbar-right" style="vertical-align: bottom" data-hook="module-nav-tabs">
+          <li id="overview-nav-tab" class="<%= "active" if module_overview? %>">
+            <a href="<%= my_module_path(@my_module) %>" title="">
+              <span class="hidden-sm hidden-md"><%=t "nav2.modules.overview" %></span>
+              <span class="hidden-xs hidden-lg glyphicon glyphicon-circle-arrow-right"></span>
+            </a>
+          </li>
           <% if can_view_module_protocols(@my_module) then %>
-            <li id="steps-nav-tab" class="<%= "active" if is_module_protocols? %>">
+            <li id="steps-nav-tab" class="<%= "active" if module_protocols? %>">
               <a href="<%= protocols_my_module_url(@my_module) %>" title="<%=t "nav2.modules.steps" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.modules.steps" %></span>
                 <span class="hidden-xs hidden-lg glyphicon glyphicon-circle-arrow-right"></span>
@@ -139,7 +131,7 @@
             </li>
           <% end %>
           <% if can_view_results_in_module(@my_module) then %>
-            <li id="results-nav-tab" class="<%= "active" if is_module_results? %>">
+            <li id="results-nav-tab" class="<%= "active" if module_results? %>">
               <a href="<%= results_my_module_url(@my_module) %>" title="<%=t "nav2.modules.results" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.modules.results" %></span>
                 <span class="hidden-xs hidden-lg glyphicon glyphicon-th"></span>
@@ -147,7 +139,7 @@
             </li>
           <% end %>
           <% if can_view_module_activities(@my_module) then %>
-            <li id="activities-nav-tab" class="<%= "active" if is_module_activities? %>">
+            <li id="activities-nav-tab" class="<%= "active" if module_activities? %>">
               <a href="<%= activities_my_module_url(@my_module) %>" title="<%=t "nav2.modules.activities" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.modules.activities" %></span>
                 <span class="hidden-xs hidden-lg glyphicon glyphicon-equalizer"></span>
@@ -155,30 +147,15 @@
             </li>
           <% end %>
           <% if can_view_module_samples(@my_module) then %>
-            <li id="module-samples-nav-tab" class="<%= "active" if is_module_samples? %>">
+            <li id="module-samples-nav-tab" class="<%= "active" if module_samples? %>">
               <a href="<%= samples_my_module_url(@my_module) %>" title="<%=t "nav2.modules.samples" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.modules.samples" %></span>
                 <span class="hidden-xs hidden-lg glyphicon glyphicon-tint"></span>
               </a>
             </li>
           <% end %>
-          <% if can_view_reports(@my_module.experiment.project) then %>
-            <li id="reports-nav-tab" >
-              <a href="<%= project_reports_url(@my_module.experiment.project) %>" title="<%=t "nav2.projects.reports" %>">
-                <span class="hidden-sm hidden-md"><%=t "nav2.projects.reports" %></span>
-                <span class="hidden-xs hidden-lg glyphicon glyphicon-list-alt"></span>
-              </a>
-            </li>
-          <% end %>
-          <% if can_view_module_archive(@my_module) then %>
-            <li id="archive-nav-tab" class="<%= "active" if is_module_archive? %>">
-              <a href="<%= archive_my_module_url(@my_module) %>">
-                <span class="glyphicon glyphicon-briefcase" title="<%= t'nav2.modules.archive' %>"></span></a>
-            </li>
-          <% end %>
-
-        <% end %>
-      </ul>
+        </ul>
+      <% end %>
 
       <!-- Breadcrumbs, displayed on large screens -->
       <ul class="breadcrumb hidden-xs">

--- a/app/views/shared/_secondary_navigation.html.erb
+++ b/app/views/shared/_secondary_navigation.html.erb
@@ -115,14 +115,14 @@
           <% end %>
         </ul>
       <% elsif module_page? %>
-        <ul class="nav navbar-nav navbar-right" style="vertical-align: bottom" data-hook="module-nav-tabs">
+        <ul class="nav navbar-nav navbar-right" style="vertical-align: bottom">
           <li id="overview-nav-tab" class="<%= "active" if module_overview? %>">
             <a href="<%= my_module_path(@my_module) %>" title="">
               <span class="hidden-sm hidden-md"><%=t "nav2.modules.overview" %></span>
-              <span class="hidden-xs hidden-lg glyphicon glyphicon-circle-arrow-right"></span>
+              <span class="hidden-xs hidden-lg glyphicon glyphicon-blackboard"></span>
             </a>
           </li>
-          <% if can_view_module_protocols(@my_module) then %>
+          <% if can_view_module_protocols(@my_module) && @my_module.shown_tabs.include?('protocols') %>
             <li id="steps-nav-tab" class="<%= "active" if module_protocols? %>">
               <a href="<%= protocols_my_module_url(@my_module) %>" title="<%=t "nav2.modules.steps" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.modules.steps" %></span>
@@ -130,7 +130,7 @@
               </a>
             </li>
           <% end %>
-          <% if can_view_results_in_module(@my_module) then %>
+          <% if can_view_results_in_module(@my_module) && @my_module.shown_tabs.include?('results') %>
             <li id="results-nav-tab" class="<%= "active" if module_results? %>">
               <a href="<%= results_my_module_url(@my_module) %>" title="<%=t "nav2.modules.results" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.modules.results" %></span>
@@ -138,7 +138,7 @@
               </a>
             </li>
           <% end %>
-          <% if can_view_module_activities(@my_module) then %>
+          <% if can_view_module_activities(@my_module) && @my_module.shown_tabs.include?('activity') %>
             <li id="activities-nav-tab" class="<%= "active" if module_activities? %>">
               <a href="<%= activities_my_module_url(@my_module) %>" title="<%=t "nav2.modules.activities" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.modules.activities" %></span>
@@ -146,12 +146,53 @@
               </a>
             </li>
           <% end %>
-          <% if can_view_module_samples(@my_module) then %>
+          <% if can_view_module_samples(@my_module) && @my_module.shown_tabs.include?('samples') %>
             <li id="module-samples-nav-tab" class="<%= "active" if module_samples? %>">
               <a href="<%= samples_my_module_url(@my_module) %>" title="<%=t "nav2.modules.samples" %>">
                 <span class="hidden-sm hidden-md"><%=t "nav2.modules.samples" %></span>
                 <span class="hidden-xs hidden-lg glyphicon glyphicon-tint"></span>
               </a>
+            </li>
+          <% end %>
+            <!-- Deface hook to inject additional tabs after this one-->
+            <li data-hook="module-nav-tabs"></li>
+          <% if can_edit_module_tabs(@my_module) %>
+            <li class="dropdown" data-role="module-tab-selector" data-url="<%= toggle_tab_my_module_path(@my_module) %>">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                <span class="glyphicon glyphicon-menu-down"></span>
+              </a>
+              <ul class="dropdown-menu dropdown-menu-task-tab-selector" data-hook="module-tab-selector">
+                <li class="disabled">
+                  <a href="#">
+                    <input type="checkbox" checked="checked">
+                    <%= t('nav2.modules.overview') %>
+                  </a>
+                </li>
+                <li class="<%= 'disabled' if (@my_module.shown_tabs.include?('protocols') && @my_module.protocols.count > 0) %>">
+                  <a href="#" data-tab="protocols">
+                    <input type="checkbox" <%= 'checked="checked"' if @my_module.shown_tabs.include?('protocols') %>>
+                    <%= t('nav2.modules.steps') %>
+                  </a>
+                </li>
+                <li class="<%= 'disabled' if (@my_module.shown_tabs.include?('results') && @my_module.results.count > 0) %>">
+                  <a href="#" data-tab="results">
+                    <input type="checkbox" <%= 'checked="checked"' if @my_module.shown_tabs.include?('results') %>>
+                    <%= t('nav2.modules.results') %>
+                  </a>
+                </li>
+                <li>
+                  <a href="#" data-tab="activity">
+                    <input type="checkbox" <%= 'checked="checked"' if @my_module.shown_tabs.include?('activity') %>>
+                    <%= t('nav2.modules.activities') %>
+                  </a>
+                </li>
+                <li class="<%= 'disabled' if (@my_module.shown_tabs.include?('samples') && @my_module.samples.count > 0) %>">
+                  <a href="#" data-tab="samples">
+                    <input type="checkbox" <%= 'checked="checked"' if @my_module.shown_tabs.include?('samples') %>>
+                    <%= t('nav2.modules.samples') %>
+                  </a>
+                </li>
+              </ul>
             </li>
           <% end %>
         </ul>
@@ -217,3 +258,5 @@
   </div>
 </nav>
 <% end %>
+
+<%= javascript_include_tag("secondary_navigation") %>

--- a/app/views/shared/_secondary_navigation.html.erb
+++ b/app/views/shared/_secondary_navigation.html.erb
@@ -126,7 +126,6 @@
             <%= my_module_tab_li(
                   @my_module,
                   'protocols',
-                  protocols_my_module_path(@my_module),
                   module_protocols?,
                   'glyphicon-circle-arrow-right',
                   { id: 'steps-nav-tab' }
@@ -137,7 +136,6 @@
             <%= my_module_tab_li(
                   @my_module,
                   'results',
-                  results_my_module_path(@my_module),
                   module_results?,
                   'glyphicon-th',
                   { id: 'results-nav-tab' }
@@ -147,8 +145,7 @@
           <% if can_view_module_activities(@my_module) %>
             <%= my_module_tab_li(
                   @my_module,
-                  'activity',
-                  activities_my_module_path(@my_module),
+                  'activities',
                   module_activities?,
                   'glyphicon-equalizer',
                   { id: 'activities-nav-tab' }
@@ -159,7 +156,6 @@
             <%= my_module_tab_li(
                   @my_module,
                   'samples',
-                  samples_my_module_path(@my_module),
                   module_samples?,
                   'glyphicon-tint',
                   { id: 'module-samples-nav-tab' }
@@ -182,7 +178,7 @@
                 </li>
                 <%= my_module_tab_selector_tab_li(@my_module, 'protocols', @my_module.protocols.count == 0) %>
                 <%= my_module_tab_selector_tab_li(@my_module, 'results', @my_module.results.count == 0) %>
-                <%= my_module_tab_selector_tab_li(@my_module, 'activity') %>
+                <%= my_module_tab_selector_tab_li(@my_module, 'activities') %>
                 <%= my_module_tab_selector_tab_li(@my_module, 'samples', @my_module.samples.count == 0) %>
                 <li style="display: none;" data-hook="module-tab-selector"></li>
               </ul>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -48,6 +48,7 @@ Rails.application.config.assets.precompile += %w(protocols/import_export/export.
 Rails.application.config.assets.precompile += %w(datatables.js)
 Rails.application.config.assets.precompile += %w(search/index.js)
 Rails.application.config.assets.precompile += %w(navigation.js)
+Rails.application.config.assets.precompile += %w(secondary_navigation.js)
 Rails.application.config.assets.precompile += %w(datatables.css)
 Rails.application.config.assets.precompile += %w(my_modules.js)
 Rails.application.config.assets.precompile += %w(direct-upload.js)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,7 +93,7 @@ en:
       overview: "Overview"
       protocols: "Protocols"
       results: "Results"
-      activity: "Activity"
+      activities: "Activity"
       samples: "Samples"
       archive: "Archive"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -90,6 +90,7 @@ en:
     experiments:
       canvas: "Overview"
     modules:
+      overview: "Overview"
       steps: "Protocols"
       results: "Results"
       activities: "Activity"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -91,9 +91,9 @@ en:
       canvas: "Overview"
     modules:
       overview: "Overview"
-      steps: "Protocols"
+      protocols: "Protocols"
       results: "Results"
-      activities: "Activity"
+      activity: "Activity"
       samples: "Samples"
       archive: "Archive"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,12 +177,15 @@ Rails.application.routes.draw do
       # AJAX popup accessed from full-zoom canvas for single module,
       # as well as full activities view (HTML) for single module
       get 'description'
-      get 'activities'
       get 'activities_tab' # Activities in tab view for single module
       get 'due_date'
+
+      # Tabs
       get 'protocols' # Protocols view for single module
       get 'results' # Results view for single module
+      get 'activities'
       get 'samples' # Samples view for single module
+
       get 'archive' # Archive view for single module
       post 'samples_index' # Renders sample datatable for single module (ajax action)
       post :assign_samples, constraints: CommitParamRouting.new(MyModulesController::ASSIGN_SAMPLES), action: :assign_samples

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -188,6 +188,7 @@ Rails.application.routes.draw do
       post :assign_samples, constraints: CommitParamRouting.new(MyModulesController::ASSIGN_SAMPLES), action: :assign_samples
       post :assign_samples, constraints: CommitParamRouting.new(MyModulesController::UNASSIGN_SAMPLES), action: :unassign_samples
       post :assign_samples, constraints: CommitParamRouting.new(MyModulesController::DELETE_SAMPLES), action: :delete_samples
+      post 'toggle_tab'
     end
 
     # Those routes are defined outside of member block to preserve original id parameters in URL.

--- a/db/migrate/20161017111700_add_tab_selector_support.rb
+++ b/db/migrate/20161017111700_add_tab_selector_support.rb
@@ -1,0 +1,15 @@
+class AddTabSelectorSupport < ActiveRecord::Migration
+  def up
+    add_column :my_modules,
+               :shown_tabs,
+               :jsonb,
+               default: [],
+               null: false
+
+    MyModule.update_all(shown_tabs: %w(protocols results activity samples))
+  end
+
+  def down
+    remove_column :my_modules, :shown_tabs
+  end
+end

--- a/db/migrate/20161017111700_add_tab_selector_support.rb
+++ b/db/migrate/20161017111700_add_tab_selector_support.rb
@@ -6,7 +6,7 @@ class AddTabSelectorSupport < ActiveRecord::Migration
                default: [],
                null: false
 
-    MyModule.update_all(shown_tabs: %w(protocols results activity samples))
+    MyModule.update_all(shown_tabs: %w(protocols results activities samples))
   end
 
   def down

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161012112900) do
+ActiveRecord::Schema.define(version: 20161017111700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -216,6 +216,7 @@ ActiveRecord::Schema.define(version: 20161012112900) do
     t.integer  "nr_of_assigned_samples", default: 0
     t.integer  "workflow_order",         default: -1,    null: false
     t.integer  "experiment_id",          default: 0,     null: false
+    t.jsonb    "shown_tabs",             default: [],    null: false
   end
 
   add_index "my_modules", ["archived_by_id"], name: "index_my_modules_on_archived_by_id", using: :btree


### PR DESCRIPTION
This MR implements the first version of the tab selector functionality. The tab selection should work, however, work is not done. I'm just pushing this branch so we can continue working on other features ASAP.

Listing below is the work left to do:
* Edit canvas doesn't work. Also, additional stuff needs to be done:
  * as soon as a sample is assigned onto `my_module`, it should get a samples tab shown if it isn't shown yet;
  * you can click "see all activities" link when on canvas; this should enable activities tab if it's not shown yet.
  * when cloning tasks/modules, clone the shown tabs as well.
* Refactor the whole tabs code into an extensible, yet more user-friendly way (`Extensions` initializer class with extensible JSON, which tells all about tabs (good for names, URLs, bad for Ruby code), or maybe extensible Ruby classes architecture (each tab is its own class, completely separated from `ActiveRecords`).

I've also wrote a [short guide](https://gist.github.com/Ducz0r/4fe3b42dd852a1fe14b8eba7a56aa460) (for future reference) on what needs to be done to add a new tab. This is a good example that it's way too much work at the moment, and the extensibility needs to be upgraded.