### PR TITLE
Tab selector fixes

### DIFF
--- a/app/assets/javascripts/secondary_navigation.js
+++ b/app/assets/javascripts/secondary_navigation.js
@@ -8,13 +8,6 @@
     // Disable checkboxes if neccesary
     parent.find('li.disabled input[type=checkbox]').attr('disabled');
 
-    // Prevent clicks on checkboxes in dropdown
-    parent.find('input[type=checkbox]').on('click', function(ev) {
-      this.checked = !this.checked;
-      ev.preventDefault();
-      return false;
-    });
-
     // Toggle tab functionality
     parent.find('li:not(.disabled) [data-tab]').on('click', function() {
       var $this = $(this);

--- a/app/controllers/my_modules_controller.rb
+++ b/app/controllers/my_modules_controller.rb
@@ -416,7 +416,7 @@ class MyModulesController < ApplicationController
 
   def check_if_tab_is_shown
     unless @my_module.shown_tabs.include?(action_name)
-      if params[:show_flash] then
+      if params[:show_flash]
         flash[:notice] = t("my_modules.tabs.flash_#{action_name}")
         flash.keep(:notice)
       end

--- a/app/controllers/my_modules_controller.rb
+++ b/app/controllers/my_modules_controller.rb
@@ -415,8 +415,13 @@ class MyModulesController < ApplicationController
   end
 
   def check_if_tab_is_shown
-    redirect_to(action: :show) && return unless
-      @my_module.shown_tabs.include?(action_name)
+    unless @my_module.shown_tabs.include?(action_name)
+      if params[:show_flash] then
+        flash[:notice] = t("my_modules.tabs.flash_#{action_name}")
+        flash.keep(:notice)
+      end
+      redirect_to(action: :show) && return
+    end
   end
 
   def my_module_params

--- a/app/helpers/my_module_tabs_helper.rb
+++ b/app/helpers/my_module_tabs_helper.rb
@@ -23,10 +23,14 @@ module MyModuleTabsHelper
   end
 
   def my_module_tab_selector_tab_li(my_module, tab)
+    toggle_disabled = my_module_tab_toggle_disabled?(my_module, tab)
     res = <<-eos
-    <li class="#{'disabled' if my_module_tab_toggle_disabled?(my_module, tab)}">
+    <li class="#{'disabled' if toggle_disabled}">
       <a href="#" data-tab="#{tab}">
-        <input type="checkbox" #{'checked="checked"' if my_module.shown_tabs.include?(tab)}>
+        <input type="checkbox"
+          #{'checked="checked"' if my_module.shown_tabs.include?(tab)}
+          #{'disabled="disabled"' if toggle_disabled}
+        >
         #{sanitize(t('nav2.modules.' + tab))}
       </a>
     </li>

--- a/app/models/sample_my_module.rb
+++ b/app/models/sample_my_module.rb
@@ -1,5 +1,6 @@
 class SampleMyModule < ActiveRecord::Base
   after_create :increment_nr_of_module_samples
+  after_create :check_tab_on_module
   after_destroy :decrement_nr_of_module_samples
 
   validates :sample, :my_module, presence: true
@@ -21,5 +22,9 @@ class SampleMyModule < ActiveRecord::Base
   def decrement_nr_of_module_samples
     my_module.decrement!(:nr_of_assigned_samples)
     sample.decrement!(:nr_of_modules_assigned_to)
+  end
+
+  def check_tab_on_module
+    my_module.check_tab('samples')
   end
 end

--- a/app/views/my_modules/_activities.html.erb
+++ b/app/views/my_modules/_activities.html.erb
@@ -11,5 +11,5 @@
     <% end %>
   <% end %>
   <hr>
-  <li><%= link_to t("experiments.canvas.popups.more_activities"), activities_my_module_path(@my_module) %></li>
+  <li><%= link_to t("experiments.canvas.popups.more_activities"), activities_my_module_path(@my_module, show_flash: true) %></li>
 </ul>

--- a/app/views/sample_my_modules/_index.html.erb
+++ b/app/views/sample_my_modules/_index.html.erb
@@ -9,5 +9,5 @@
     <% end %>
   <% end %>
   <hr>
-  <li><%= link_to t("experiments.canvas.popups.manage_samples"), samples_my_module_url(id: @my_module.id) %></li>
+  <li><%= link_to t("experiments.canvas.popups.manage_samples"), samples_my_module_url(id: @my_module.id, show_flash: true) %></li>
 </ul>

--- a/app/views/shared/_secondary_navigation.html.erb
+++ b/app/views/shared/_secondary_navigation.html.erb
@@ -172,7 +172,7 @@
               <ul class="dropdown-menu dropdown-menu-module-tab-selector">
                 <li class="disabled">
                   <a href="#">
-                    <input type="checkbox" checked="checked">
+                    <input type="checkbox" checked="checked" disabled="disabled">
                     <%= t('nav2.modules.overview') %>
                   </a>
                 </li>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -608,6 +608,11 @@ en:
       head_title: "%{project} | %{module} | Activity"
       no_activities: "There are no activities for this task."
       more_activities: "Load older activities"
+    tabs:
+      flash_protocols: "You don't have protocols tab enabled for the current task. Use tab selector to toggle protocols tab."
+      flash_results: "You don't have results tab enabled for the current task. Use tab selector to toggle results tab."
+      flash_activities: "You don't have activity tab enabled for the current task. Use tab selector to toggle activity tab."
+      flash_samples: "You don't have samples tab enabled for the current task. Use tab selector to toggle samples tab."
 
   experiments:
     new:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -665,8 +665,8 @@ ActiveRecord::Schema.define(version: 20161017111700) do
     t.boolean  "recent_notification",               default: true
     t.boolean  "assignments_notification_email",    default: false
     t.boolean  "recent_notification_email",         default: false
-    t.integer  "current_organization_id"
     t.boolean  "system_message_notification_email", default: false
+    t.integer  "current_organization_id"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree


### PR DESCRIPTION
* When cloning tasks, the shown tabs are also cloned,
* When samples are assigned onto a task, its samples tab is automatically set to shown,
* Now you can also click on a checkbox from tab selector to toggle tab (previously you had to click on the text),
* Show a flash message when navigating to activity or samples tab of the task from canvas, and the tab is not shown.