### PR TITLE
Add check in application controller to always set current org if nil

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   helper_method :current_organization
   before_action :generate_intro_tutorial, if: :is_current_page_root?
+  before_action :update_current_organization, if: :user_signed_in?
   around_action :set_time_zone, if: :current_user
   layout 'main'
 
@@ -78,6 +79,15 @@ class ApplicationController < ActionController::Base
         expires: 1.week.from_now
       }
       current_user.update(tutorial_status: 1)
+    end
+  end
+
+  def update_current_organization
+    if current_user.current_organization_id.blank? &&
+       current_user.organizations.count > 0
+      current_user.update(
+        current_organization_id: current_user.organizations.first.id
+      )
     end
   end
 


### PR DESCRIPTION
This should hopefully fix some awkward situations where `current_organization_id` can be nil (e.g. when inviting a new user to the team).