### PR TITLE
Automatically resize textarea elements [SCI-637]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'hammerjs-rails'
 gem 'introjs-rails' # Create quick tutorials
 gem 'js_cookie_rails' # Simple JS API for cookies
 gem 'spinjs-rails'
+gem 'autosize-rails' # jQuery autosize plugin
 
 gem 'underscore-rails'
 gem 'turbolinks'

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -6,6 +6,7 @@
 //= require jquery.remotipart
 //= require jquery.mousewheel.min
 //= require jquery.scrollTo
+//= require jquery.autosize
 //= require jquery-ui/widget
 //= require jquery-ui/mouse
 //= require jquery-ui/draggable

--- a/app/assets/javascripts/sitewide/textarea_autosize.js
+++ b/app/assets/javascripts/sitewide/textarea_autosize.js
@@ -1,0 +1,19 @@
+$(document).on('focus', 'textarea', function() {
+  var $this = $(this);
+  var height = $this.css('height');
+
+  // Set the nr. of rows to 1 if small textarea
+  if ($this.hasClass('textarea-sm')) {
+    $this.attr('rows', '1');
+  }
+
+  // Initialize autosize plugin if it's not initialized yet
+  if (_.isUndefined($this.data('autosize'))) {
+    $this.autosize({append: ''});
+
+    // Restore previous height!
+    $this.css('height', height);
+  }
+
+  $this.trigger('autosize.resize');
+});

--- a/app/assets/javascripts/sitewide/textarea_autosize.js
+++ b/app/assets/javascripts/sitewide/textarea_autosize.js
@@ -1,19 +1,30 @@
-$(document).on('focus', 'textarea', function() {
-  var $this = $(this);
-  var height = $this.css('height');
+$(document).on(
+  'focus',
+  'textarea.smart-text-area:not([readonly]):not([disabled])',
+  function() {
+    var $this = $(this);
+    var height = $this.css('height');
 
-  // Set the nr. of rows to 1 if small textarea
-  if ($this.hasClass('textarea-sm')) {
-    $this.attr('rows', '1');
+    if ($this.hasClass('textarea-sm-present')) {
+      $this
+      .removeClass('textarea-sm-present')
+      .addClass('textarea-sm');
+      $this.attr('rows', '1');
+    } else if ($this.hasClass('textarea-sm')) {
+      // Set the nr. of rows to 1 if small textarea
+      $this.attr('rows', '1');
+    } else {
+      $this.removeAttr('rows');
+    }
+
+    // Initialize autosize plugin if it's not initialized yet
+    if (_.isUndefined($this.data('autosize'))) {
+      $this.autosize({append: ''});
+
+      // Restore previous height!
+      $this.css('height', height);
+    }
+
+    $this.trigger('autosize.resize');
   }
-
-  // Initialize autosize plugin if it's not initialized yet
-  if (_.isUndefined($this.data('autosize'))) {
-    $this.autosize({append: ''});
-
-    // Restore previous height!
-    $this.css('height', height);
-  }
-
-  $this.trigger('autosize.resize');
-});
+);

--- a/app/assets/stylesheets/themes/scinote.scss
+++ b/app/assets/stylesheets/themes/scinote.scss
@@ -1497,9 +1497,10 @@ html.turbolinks-progress-bar::before {
   }
 }
 
-// Only allow vertical resizing of all text areas
+// Disable textarea resizing throughout application
+// (will be done via autosize JS plugin)
 textarea {
-  resize: vertical;
+  resize: none;
 }
 
 textarea.textarea-sm {
@@ -1511,14 +1512,7 @@ textarea.textarea-sm {
   }
 }
 
-.comment-form {
-  textarea {
-    height: 34px;
-    min-height: 34px;
-  }
-
-  .btn.btn-default {
-    height: calc(100% + 14px);
-    min-height: 34px;
-  }
+.comment-form .btn.btn-default {
+  height: calc(100% + 14px);
+  min-height: 34px;
 }

--- a/app/assets/stylesheets/themes/scinote.scss
+++ b/app/assets/stylesheets/themes/scinote.scss
@@ -1512,7 +1512,22 @@ textarea.textarea-sm {
   }
 }
 
-.comment-form .btn.btn-default {
-  height: calc(100% + 14px);
-  min-height: 34px;
+.comment-form .input-group {
+  height: 100%;
+
+  textarea {
+    -webkit-margin-before: 1px;
+    -webkit-margin-after: 1px;
+  }
+
+  .input-group-btn {
+    height: 100%;
+
+    .btn.btn-default {
+      height: 100%;
+      min-height: 34px;
+      -webkit-padding-before: 0;
+      -webkit-padding-after: 0;
+    }
+  }
 }

--- a/app/helpers/bootstrap_form_helper.rb
+++ b/app/helpers/bootstrap_form_helper.rb
@@ -237,5 +237,28 @@ module BootstrapFormHelper
       res << "</div>"
       res.html_safe
     end
+
+    # Returns smart <textarea> that dynamically resizes depending on the user
+    # input. Also has an option 'single_line: true' to render it as a one-line
+    # (imagine <input type="text">) input field that only grows beyond one line
+    # if inputting a larger text (otherwise, by default it spans 2 lines).
+    #
+    # Other than that, it accepts same options as regular text_area helper.
+    def smart_text_area(name, opts = {})
+      opts[:class] = [opts[:class], 'smart-text-area'].join(' ')
+      if !opts[:rows] && @object
+        opts[:rows] =
+          @object.public_send(name).try(:lines).try(:count)
+      end
+      opts.delete(:rows) if opts[:rows].nil?
+      if opts[:single_line]
+        if opts[:rows]
+          opts[:class] = [opts[:class], 'textarea-sm-present'].join(' ')
+        else
+          opts[:class] = [opts[:class], 'textarea-sm'].join(' ')
+        end
+      end
+      text_area(name, opts)
+    end
   end
 end

--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -1,7 +1,7 @@
 <%= bootstrap_form_for(@comment, url: @update_url, remote: true, html: { method: :put, class: 'comment-form edit-comment-form' }, data: { role: 'edit-comment-message-form' }) do |f| %>
   <div class="form-group">
     <div class="input-group">
-      <%= f.text_area :message, class: 'textarea-sm', autofocus: true, hide_label: true, data: { role: 'message-input' }, value: @comment.message %>
+      <%= f.smart_text_area :message, single_line: true, autofocus: true, hide_label: true, data: { role: 'message-input' }, value: @comment.message %>
       <span class="input-group-btn">
         <a class="btn btn-default" data-action="save">
           <span class="glyphicon glyphicon-ok"></span>

--- a/app/views/comments/_edit.html.erb
+++ b/app/views/comments/_edit.html.erb
@@ -1,7 +1,7 @@
 <%= bootstrap_form_for(@comment, url: @update_url, remote: true, html: { method: :put, class: 'comment-form edit-comment-form' }, data: { role: 'edit-comment-message-form' }) do |f| %>
   <div class="form-group">
     <div class="input-group">
-      <%= f.text_area :message, autofocus: true, hide_label: true, data: { role: 'message-input' }, value: @comment.message %>
+      <%= f.text_area :message, class: 'textarea-sm', autofocus: true, hide_label: true, data: { role: 'message-input' }, value: @comment.message %>
       <span class="input-group-btn">
         <a class="btn btn-default" data-action="save">
           <span class="glyphicon glyphicon-ok"></span>

--- a/app/views/experiments/_form.html.erb
+++ b/app/views/experiments/_form.html.erb
@@ -13,9 +13,9 @@
 <div class="row">
   <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
     <div class="form-group">
-      <%= form.text_area :description,
-                         label: t('experiments.new.description'),
-                         id: 'experiment-description' %>
+      <%= form.smart_text_area :description,
+                               label: t('experiments.new.description'),
+                               id: 'experiment-description' %>
     </div>
   </div>
 </div>

--- a/app/views/my_module_comments/_index.html.erb
+++ b/app/views/my_module_comments/_index.html.erb
@@ -19,7 +19,7 @@
     <li>
       <hr>
       <%= bootstrap_form_for :comment, url: { format: :json }, method: :post, remote: true, html: { class: 'comment-form' } do |f| %>
-        <%= f.text_area :message, class: 'textarea-sm', hide_label: true, placeholder: t("experiments.canvas.popups.comment_placeholder"), append: f.submit("+"), help: '.' %>
+        <%= f.smart_text_area :message, single_line: true, hide_label: true, placeholder: t("experiments.canvas.popups.comment_placeholder"), append: f.submit("+"), help: '.' %>
       <% end %>
     </li>
   </ul>

--- a/app/views/my_module_comments/_index.html.erb
+++ b/app/views/my_module_comments/_index.html.erb
@@ -19,7 +19,7 @@
     <li>
       <hr>
       <%= bootstrap_form_for :comment, url: { format: :json }, method: :post, remote: true, html: { class: 'comment-form' } do |f| %>
-        <%= f.text_area :message, hide_label: true, placeholder: t("experiments.canvas.popups.comment_placeholder"), append: f.submit("+"), help: '.' %>
+        <%= f.text_area :message, class: 'textarea-sm', hide_label: true, placeholder: t("experiments.canvas.popups.comment_placeholder"), append: f.submit("+"), help: '.' %>
       <% end %>
     </li>
   </ul>

--- a/app/views/my_modules/_description.html.erb
+++ b/app/views/my_modules/_description.html.erb
@@ -1,3 +1,3 @@
 <%= bootstrap_form_for @my_module, url: my_module_path(@my_module, format: :json), remote: :true do |f| %>
-  <%= f.text_area :description, label: t("my_modules.description.label") %>
+  <%= f.smart_text_area :description, label: t("my_modules.description.label") %>
 <% end %>

--- a/app/views/project_comments/_index.html.erb
+++ b/app/views/project_comments/_index.html.erb
@@ -18,7 +18,7 @@
     <li>
       <hr>
       <%= bootstrap_form_for :comment, url: {format: :json}, method: :post, remote: true, html: { class: 'comment-form' } do |f| %>
-        <%= f.text_area :message, class: 'textarea-sm', hide_label: true, placeholder: t('projects.index.comment_placeholder'), append: f.submit('+'), help: '.' %>
+        <%= f.smart_text_area :message, single_line: true, hide_label: true, placeholder: t('projects.index.comment_placeholder'), append: f.submit('+'), help: '.' %>
       <% end %>
     </li>
   </ul>

--- a/app/views/project_comments/_index.html.erb
+++ b/app/views/project_comments/_index.html.erb
@@ -18,7 +18,7 @@
     <li>
       <hr>
       <%= bootstrap_form_for :comment, url: {format: :json}, method: :post, remote: true, html: { class: 'comment-form' } do |f| %>
-        <%= f.text_area :message, hide_label: true, placeholder: t('projects.index.comment_placeholder'), append: f.submit('+'), help: '.' %>
+        <%= f.text_area :message, class: 'textarea-sm', hide_label: true, placeholder: t('projects.index.comment_placeholder'), append: f.submit('+'), help: '.' %>
       <% end %>
     </li>
   </ul>

--- a/app/views/protocols/header/_edit_authors_modal_body.html.erb
+++ b/app/views/protocols/header/_edit_authors_modal_body.html.erb
@@ -1,3 +1,3 @@
 <%= bootstrap_form_for @protocol, url: metadata_protocol_path(@protocol, format: :json), remote: :true do |f| %>
-  <%= f.text_area :authors, label: t("protocols.header.edit_authors_modal.label") %>
+  <%= f.smart_text_area :authors, label: t("protocols.header.edit_authors_modal.label") %>
 <% end %>

--- a/app/views/protocols/header/_edit_description_modal_body.html.erb
+++ b/app/views/protocols/header/_edit_description_modal_body.html.erb
@@ -1,3 +1,3 @@
 <%= bootstrap_form_for @protocol, url: metadata_protocol_path(@protocol, format: :json), remote: :true do |f| %>
-  <%= f.text_area :description, label: t("protocols.header.edit_description_modal.label") %>
+  <%= f.smart_text_area :description, label: t("protocols.header.edit_description_modal.label") %>
 <% end %>

--- a/app/views/reports/new/modal/_save.html.erb
+++ b/app/views/reports/new/modal/_save.html.erb
@@ -1,5 +1,5 @@
 <%= bootstrap_form_for [@project, @report], remote: true, url: @url, method: @method, html: { id: "save-report-form" } do |f| %>
   <%= f.text_field :name, label: t("projects.reports.elements.modals.save_report.name"), placeholder: t("projects.reports.elements.modals.save_report.name_placeholder") %>
-  <%= f.text_area :description, label: t("projects.reports.elements.modals.save_report.description"), placeholder: t("projects.reports.elements.modals.save_report.description_placeholder") %>
+  <%= f.smart_text_area :description, label: t("projects.reports.elements.modals.save_report.description"), placeholder: t("projects.reports.elements.modals.save_report.description_placeholder") %>
   <%= hidden_field_tag :report_contents, @report_contents %>
 <% end %>

--- a/app/views/result_comments/_index.html.erb
+++ b/app/views/result_comments/_index.html.erb
@@ -22,7 +22,7 @@
     <li>
       <hr>
       <%= bootstrap_form_for :comment, url: { format: :json }, method: :post, remote: true, html: { class: 'comment-form' } do |f| %>
-        <%= f.text_area :message, hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+", onclick: "processResult(event, ResultTypeEnum.COMMENT, false);"), help: '.' %>
+        <%= f.text_area :message, class: 'textarea-sm', hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+", onclick: "processResult(event, ResultTypeEnum.COMMENT, false);"), help: '.' %>
       <% end %>
     </li>
   </ul>

--- a/app/views/result_comments/_index.html.erb
+++ b/app/views/result_comments/_index.html.erb
@@ -22,7 +22,7 @@
     <li>
       <hr>
       <%= bootstrap_form_for :comment, url: { format: :json }, method: :post, remote: true, html: { class: 'comment-form' } do |f| %>
-        <%= f.text_area :message, class: 'textarea-sm', hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+", onclick: "processResult(event, ResultTypeEnum.COMMENT, false);"), help: '.' %>
+        <%= f.smart_text_area :message, single_line: true, hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+", onclick: "processResult(event, ResultTypeEnum.COMMENT, false);"), help: '.' %>
       <% end %>
     </li>
   </ul>

--- a/app/views/step_comments/_index.html.erb
+++ b/app/views/step_comments/_index.html.erb
@@ -22,7 +22,7 @@
     <li>
       <hr>
       <%= bootstrap_form_for :comment, url: { format: :json }, html: { class: 'comment-form', id: "step-comment-#{@step.id}" }, method: :post, remote: true do |f| %>
-        <%= f.text_area :message, hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+"), help: '.' %>
+        <%= f.text_area :message, class: 'textarea-sm', hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+"), help: '.' %>
       <% end %>
     </li>
   </ul>

--- a/app/views/step_comments/_index.html.erb
+++ b/app/views/step_comments/_index.html.erb
@@ -22,7 +22,7 @@
     <li>
       <hr>
       <%= bootstrap_form_for :comment, url: { format: :json }, html: { class: 'comment-form', id: "step-comment-#{@step.id}" }, method: :post, remote: true do |f| %>
-        <%= f.text_area :message, class: 'textarea-sm', hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+"), help: '.' %>
+        <%= f.smart_text_area :message, single_line: true, hide_label: true, placeholder: t("general.comment_placeholder"), append: f.submit("+"), help: '.' %>
       <% end %>
     </li>
   </ul>

--- a/app/views/steps/_form_checklists.html.erb
+++ b/app/views/steps/_form_checklists.html.erb
@@ -9,7 +9,7 @@
     </div>
   </div>
   <div class="panel-body">
-    <%= ff.text_area :name, label: t("protocols.steps.new.checklist_name"), class: "checklist_name textarea-sm", autofocus: true, placeholder: t("protocols.steps.new.checklist_name_placeholder") %>
+    <%= ff.smart_text_area :name, label: t("protocols.steps.new.checklist_name"), class: "checklist_name", autofocus: true, placeholder: t("protocols.steps.new.checklist_name_placeholder") %>
     <%= ff.label t("protocols.steps.new.checklist_items") %>
     <ul>
       <%= ff.nested_fields_for :checklist_items, ordered_checklist_items(ff.object) do |chkItems| %>
@@ -18,7 +18,7 @@
             <span class="glyphicon glyphicon-chevron-right handle-move pull-left"></span>
             <div class="row">
               <div class="col-xs-6">
-                <%= chkItems.text_area :text, autofocus: true, placeholder: t("protocols.steps.new.checklist_item_placeholder"), hide_label: true, class: "checklist-item-text form-control textarea-sm" %>
+                <%= chkItems.smart_text_area :text, autofocus: true, placeholder: t("protocols.steps.new.checklist_item_placeholder"), hide_label: true, class: "checklist-item-text form-control", single_line: true %>
                 <%= chkItems.hidden_field :position, class: "checklist-item-pos" %>
               </div>
               <div class="col-xs-1">

--- a/app/views/users/settings/organizations/_description_modal_body.html.erb
+++ b/app/views/users/settings/organizations/_description_modal_body.html.erb
@@ -1,3 +1,3 @@
 <%= bootstrap_form_for org, url: update_organization_path(org, format: :json), remote: :true, method: :put do |f| %>
-  <%= f.text_area :description, label: t("users.settings.organizations.edit.description_label") %>
+  <%= f.smart_text_area :description, label: t("users.settings.organizations.edit.description_label") %>
 <% end %>


### PR DESCRIPTION
This MR includes a jQuery addon that allows for automatic resizing of `<textarea>` elements.

It took me some time to figure out a styling solution that correctly renders the "add comment" buttons on Firefox & Chrome...