### PR TITLE
Save first time tutorial Activity-s without callbacks [SCI-655]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem 'faker' # Generate fake data
 gem 'auto_strip_attributes', '~> 2.1' # Removes unnecessary whitespaces from ActiveRecord or ActiveModel attributes
 gem 'deface', '~> 1.0'
 gem 'nokogiri' # HTML/XML parser
+gem 'sneaky-save', git: 'git://github.com/einzige/sneaky-save.git'
 
 gem 'paperclip', '~> 4.3' # File attachment, image attachment library
 gem 'aws-sdk', '~> 2.2.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: git://github.com/einzige/sneaky-save.git
+  revision: 03866e838f62a4b13e15784974fcc13e14cd9502
+  specs:
+    sneaky-save (0.1.1)
+      activerecord (>= 3.2.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -367,6 +374,7 @@ DEPENDENCIES
   shoulda-context
   shoulda-matchers (>= 3.0.1)
   skylight
+  sneaky-save!
   spinjs-rails
   starscope
   turbolinks

--- a/app/utilities/delayed_uploader_tutorial.rb
+++ b/app/utilities/delayed_uploader_tutorial.rb
@@ -1,51 +1,56 @@
-class DelayedUploaderTutorial
+module DelayedUploaderTutorial
+  # Get asset from tutorial_files folder
+  def self.get_asset(user, file_name)
+    Asset.new(
+      file: File.open(
+        "#{Rails.root}/app/assets/tutorial_files/#{file_name}", 'r'
+      ),
+      created_by: user,
+      last_modified_by: user
+    )
+  end
 
-    # Get asset from tutorial_files folder
-    def self.get_asset(user, file_name)
-      Asset.new(
-        file: File.open("#{Rails.root}/app/assets/tutorial_files/#{file_name}", "r"),
-        created_by: user,
-        last_modified_by: user
+  # Generates results asset for given module, file_name assumes file is located
+  # in tutorial_files.
+  def self.generate_result_asset(
+    my_module:,
+    current_user:,
+    result_name:,
+    created_at: Time.now,
+    file_name:
+  )
+    temp_asset = get_asset(current_user, file_name)
+    temp_result = Result.new(
+      created_at: created_at,
+      user: current_user,
+      my_module: my_module,
+      name: result_name,
+      asset: temp_asset
+    )
+
+    temp_result.save
+    temp_asset.save
+    temp_asset.post_process_file(my_module.experiment.project.organization)
+
+    # Create result activity
+    Activity.new(
+      type_of: :add_result,
+      project: my_module.experiment.project,
+      my_module: my_module,
+      user: current_user,
+      created_at: temp_result.created_at,
+      message: I18n.t(
+        'activities.add_asset_result',
+        user: current_user.full_name,
+        result: temp_result.name
       )
-    end
+    ).sneaky_save
+  end
 
-    # Generates results asset for given module, file_name assumes file is located
-    # in tutorial_files.
-    def self.generate_result_asset(my_module:, current_user:,
-                                   result_name:, created_at: Time.now,
-                                   file_name:)
-      temp_asset = DelayedUploaderTutorial.get_asset(current_user, file_name)
-      temp_result = Result.new(
-        created_at: created_at,
-        user: current_user,
-        my_module: my_module,
-        name: result_name,
-        asset: temp_asset
-      )
-
-      temp_result.save
-      temp_asset.save
-      temp_asset.post_process_file(my_module.experiment.project.organization)
-
-      # Create result activity
-      Activity.create(
-        type_of: :add_result,
-        project: my_module.experiment.project,
-        my_module: my_module,
-        user: current_user,
-        created_at: temp_result.created_at,
-        message: I18n.t(
-            "activities.add_asset_result",
-            user: current_user.full_name,
-            result: temp_result.name
-        )
-      )
-    end
-
-    # Adds asset to existing step
-    def self.add_step_asset(step:, current_user:, file_name:)
-      temp_asset = DelayedUploaderTutorial.get_asset(current_user, file_name)
-      step.assets << temp_asset
-      temp_asset.post_process_file(step.my_module.experiment.project.organization)
-    end
+  # Adds asset to existing step
+  def self.add_step_asset(step:, current_user:, file_name:)
+    temp_asset = DelayedUploaderTutorial.get_asset(current_user, file_name)
+    step.assets << temp_asset
+    temp_asset.post_process_file(step.my_module.experiment.project.organization)
+  end
 end

--- a/app/utilities/first_time_data_generator.rb
+++ b/app/utilities/first_time_data_generator.rb
@@ -122,7 +122,7 @@ module FirstTimeDataGenerator
     )
 
     # Activity for creating project
-    Activity.create(
+    Activity.new(
       type_of: :create_project,
       user: user,
       project: project,
@@ -132,7 +132,7 @@ module FirstTimeDataGenerator
         project: project.name
       ),
       created_at: project.created_at
-    )
+    ).sneaky_save
 
     # Add a comment
     generate_project_comment(
@@ -194,7 +194,7 @@ module FirstTimeDataGenerator
       end
 
       # Create module activity
-      Activity.create(
+      Activity.new(
         type_of: :create_module,
         user: user,
         project: project,
@@ -205,7 +205,7 @@ module FirstTimeDataGenerator
           module: my_module.name
         ),
         created_at: my_module.created_at
-      )
+      ).sneaky_save
 
       UserMyModule.create(
         user: user,
@@ -213,7 +213,7 @@ module FirstTimeDataGenerator
         assigned_by: user,
         created_at: generate_random_time(my_module.created_at, 2.minutes)
       )
-      Activity.create(
+      Activity.new(
         type_of: :assign_user_to_module,
         user: user,
         project: project,
@@ -225,7 +225,7 @@ module FirstTimeDataGenerator
             assigned_by_user: user.full_name
         ),
         created_at: generate_random_time(my_module.created_at, 2.minutes)
-      )
+      ).sneaky_save
     end
 
     # Create an archived module
@@ -246,7 +246,7 @@ module FirstTimeDataGenerator
     )
 
     # Activity for creating archived module
-    Activity.create(
+    Activity.new(
       type_of: :create_module,
       user: user,
       project: project,
@@ -257,10 +257,10 @@ module FirstTimeDataGenerator
         module: archived_module.name
       ),
       created_at: archived_module.created_at
-    )
+    ).sneaky_save
 
     # Activity for archiving archived module
-    Activity.create(
+    Activity.new(
       type_of: :archive_module,
       user: user,
       project: project,
@@ -271,7 +271,7 @@ module FirstTimeDataGenerator
         module: archived_module.name
       ),
       created_at: archived_module.archived_on
-    )
+    ).sneaky_save
 
     # Assign new user to archived module
     UserMyModule.create(
@@ -280,7 +280,7 @@ module FirstTimeDataGenerator
       assigned_by: user,
       created_at: generate_random_time(archived_module.created_at, 2.minutes)
     )
-    Activity.create(
+    Activity.new(
       type_of: :assign_user_to_module,
       user: user,
       project: project,
@@ -292,7 +292,7 @@ module FirstTimeDataGenerator
           assigned_by_user: user.full_name
       ),
       created_at: generate_random_time(archived_module.created_at, 2.minutes)
-    )
+    ).sneaky_save
 
     # Assign 4 samples to modules
     samples_to_assign = []
@@ -497,7 +497,7 @@ module FirstTimeDataGenerator
     temp_result.save
 
     # Create result activity
-    Activity.create(
+    Activity.new(
       type_of: :add_result,
       project: project,
       my_module: my_modules[1],
@@ -508,7 +508,7 @@ module FirstTimeDataGenerator
         user: user.full_name,
         result: temp_result.name
       )
-    )
+    ).sneaky_save
     # ----------------- Module 3 ------------------
     module_step_names = [
       "Homogenization of the material",
@@ -547,7 +547,7 @@ module FirstTimeDataGenerator
     temp_result.save
 
     # Create result activity
-    Activity.create(
+    Activity.new(
       type_of: :add_result,
       project: project,
       my_module: my_modules[2],
@@ -558,7 +558,7 @@ module FirstTimeDataGenerator
         user: user.full_name,
         result: temp_result.name
       )
-    )
+    ).sneaky_save
 
     # Second result
     DelayedUploaderTutorial.delay(queue: :tutorial).generate_result_asset(
@@ -689,7 +689,7 @@ module FirstTimeDataGenerator
     temp_result.save
 
     # Create result activity
-    Activity.create(
+    Activity.new(
       type_of: :add_result,
       project: project,
       my_module: my_modules[5],
@@ -700,7 +700,7 @@ module FirstTimeDataGenerator
         user: user.full_name,
         result: temp_result.name
       )
-    )
+    ).sneaky_save
 
     # Results
     DelayedUploaderTutorial.delay(queue: :tutorial).generate_result_asset(
@@ -802,7 +802,7 @@ module FirstTimeDataGenerator
     temp_result.save
 
     # Create result activity
-    Activity.create(
+    Activity.new(
       type_of: :add_result,
       project: project,
       my_module: my_modules[7],
@@ -813,7 +813,7 @@ module FirstTimeDataGenerator
         user: user.full_name,
         result: temp_result.name
       )
-    )
+    ).sneaky_save
 
     # create thumbnail
     experiment.generate_workflow_img
@@ -865,7 +865,7 @@ module FirstTimeDataGenerator
       )
 
       # Create activity
-      Activity.create(
+      Activity.new(
         type_of: :create_step,
         project: my_module.experiment.project,
         my_module: my_module,
@@ -877,9 +877,9 @@ module FirstTimeDataGenerator
           step: i,
           step_name: step.name
         )
-      )
+      ).sneaky_save
       if completed then
-        Activity.create(
+        Activity.new(
           type_of: :complete_step,
           project: my_module.experiment.project,
           my_module: my_module,
@@ -893,7 +893,7 @@ module FirstTimeDataGenerator
             completed: my_module.protocol.completed_steps.count,
             all: i+1
           )
-        )
+        ).sneaky_save
 
         # Also add random comments to completed steps
         if rand < 0.3
@@ -923,7 +923,7 @@ module FirstTimeDataGenerator
       message: message,
       created_at: created_at
     )
-    Activity.create(
+    Activity.new(
       type_of: :add_comment_to_project,
       user: user,
       project: project,
@@ -931,7 +931,7 @@ module FirstTimeDataGenerator
       message: t('activities.add_comment_to_project',
                  user: user.full_name,
                  project: project.name)
-    )
+    ).sneaky_save
   end
 
   def generate_module_comment(my_module, user, message, created_at = nil)
@@ -941,7 +941,7 @@ module FirstTimeDataGenerator
       message: message,
       created_at: created_at
     )
-    Activity.create(
+    Activity.new(
       type_of: :add_comment_to_module,
       user: user,
       project: my_module.experiment.project,
@@ -950,7 +950,7 @@ module FirstTimeDataGenerator
       message: t('activities.add_comment_to_module',
                  user: user.full_name,
                  module: my_module.name)
-    )
+    ).sneaky_save
   end
 
   def generate_result_comment(result, user, message, created_at = nil)
@@ -960,7 +960,7 @@ module FirstTimeDataGenerator
       message: message,
       created_at: created_at
     )
-    Activity.create(
+    Activity.new(
       type_of: :add_comment_to_result,
       user: user,
       project: result.my_module.experiment.project,
@@ -969,7 +969,7 @@ module FirstTimeDataGenerator
       message: t('activities.add_comment_to_result',
                  user: user.full_name,
                  result: result.name)
-    )
+    ).sneaky_save
   end
 
   def generate_step_comment(step, user, message, created_at = nil)
@@ -979,7 +979,7 @@ module FirstTimeDataGenerator
       message: message,
       created_at: created_at
     )
-    Activity.create(
+    Activity.new(
       type_of: :add_comment_to_step,
       user: user,
       project: step.protocol.my_module.experiment.project,
@@ -989,6 +989,6 @@ module FirstTimeDataGenerator
                  user: user.full_name,
                  step: step.position + 1,
                  step_name: step.name)
-    )
+    ).sneaky_save
   end
 end


### PR DESCRIPTION
This PR adds a new, pretty useful little gem called [sneaky-save](https://github.com/einzige/sneaky-save). The Gem adds a new function onto `ActiveRecord`, called `sneaky_save`, which saves an entity into the database via direct SQL, therefore omitting any validations as well as callbacks (which were a pain for fixing the mentioned issue).

For reference, the other solution, [`skip_callback`](http://apidock.com/rails/ActiveSupport/Callbacks/ClassMethods/skip_callback) method that is part of  `ActiveRecord` interface is pretty bad, because it's not thread-locked, so big no-go (especially because we're also using `delayed_jobs` here).

https://biosistemika.atlassian.net/browse/SCI-655