### PR TITLE
Allow inviting of unconfirmed user onto multiple teams [SCI-676]

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -85,11 +85,6 @@ module Users
               UserOrganization.where(user: user, organization: @org).first
 
             result[:status] = :user_exists_and_in_org
-          elsif result[:status] == :user_exists && !user.confirmed?
-            # We don't want to allow inviting unconfirmed
-            # users (that were not invited as part of this action)
-            # into organizations
-            result[:status] = :user_exists_unconfirmed
           else
             # Also generate user organization relation
             user_org = UserOrganization.new(
@@ -106,7 +101,9 @@ module Users
               user_org.organization
             )
 
-            if result[:status] == :user_exists
+            if result[:status] == :user_exists && !user.confirmed?
+              result[:status] = :user_exists_unconfirmed_invited_to_org
+            elsif result[:status] == :user_exists
               result[:status] = :user_exists_invited_to_org
             else
               result[:status] = :user_created_invited_to_org

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,5 @@
 class Notification < ActiveRecord::Base
-  has_many :user_notifications, inverse_of: :notification
+  has_many :user_notifications, inverse_of: :notification, dependent: :destroy
   has_many :users, through: :user_notifications
   belongs_to :generator_user, class_name: 'User'
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -92,10 +92,13 @@ class User < ActiveRecord::Base
   has_many :restored_protocols, class_name: 'Protocol', foreign_key: 'restored_by_id', inverse_of: :restored_by
   has_many :user_notifications, inverse_of: :user
   has_many :notifications, through: :user_notifications
+
   # If other errors besides parameter "avatar" exist,
   # they will propagate to "avatar" also, so remove them
   # and put all other (more specific ones) in it
   after_validation :filter_paperclip_errors
+
+  before_destroy :destroy_notifications
 
   def name
     full_name
@@ -250,5 +253,26 @@ class User < ActiveRecord::Base
     if time_zone.nil? or ActiveSupport::TimeZone.new(time_zone).nil?
       errors.add(:time_zone)
     end
+  end
+
+  private
+
+  def destroy_notifications
+    # Find all notifications where user is the only reference
+    # on the notification, and destroy all such notifications
+    # (user_notifications are destroyed when notification is
+    # destroyed). We try to do this efficiently (hence in_groups_of).
+    nids_all = notifications.pluck(:id)
+    nids_all.in_groups_of(1000, false) do |nids|
+      Notification
+        .where(id: nids)
+        .joins(:user_notifications)
+        .group('notifications.id')
+        .having('count(notification_id) <= 1')
+        .destroy_all
+    end
+
+    # Now, simply destroy all user notification relations left
+    user_notifications.destroy_all
   end
 end

--- a/app/views/shared/_invite_users_modal_results.html.erb
+++ b/app/views/shared/_invite_users_modal_results.html.erb
@@ -10,17 +10,17 @@
     &nbsp;-&nbsp;
     <%= t('invite_users.results.user_exists') %>
   </div>
-<%   elsif result[:status] == :user_exists_unconfirmed %>
-  <div class="alert alert-info" role="alert">
-    <strong><%= result[:email] %></strong>
-    &nbsp;-&nbsp;
-    <%= t('invite_users.results.user_exists_unconfirmed', organization: @org.name) %>
-  </div>
 <%   elsif result[:status] == :user_exists_and_in_org %>
   <div class="alert alert-info" role="alert">
     <strong><%= result[:email] %></strong>
     &nbsp;-&nbsp;
     <%= t('invite_users.results.user_exists_and_in_org', organization: @org.name, role: t("user_organizations.enums.role.#{result[:user_org].role}")) %>
+  </div>
+<%   elsif result[:status] == :user_exists_unconfirmed_invited_to_org %>
+  <div class="alert alert-info" role="alert">
+    <strong><%= result[:email] %></strong>
+    &nbsp;-&nbsp;
+    <%= t('invite_users.results.user_exists_unconfirmed_invited_to_org', organization: @org.name, role: t("user_organizations.enums.role.#{result[:user_org].role}")) %>
   </div>
 <%   elsif result[:status] == :user_exists_invited_to_org %>
   <div class="alert alert-info" role="alert">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1439,7 +1439,7 @@ en:
     results:
       heading: "Invitation results:"
       user_exists: "User is already a member of sciNote."
-      user_exists_unconfirmed: "User is already a member of sciNote but is not confirmed yet - cannot invite to team %{organization}."
+      user_exists_unconfirmed_invited_to_org: "User is already a member of sciNote but is not confirmed yet - successfully invited to team %{organization} as %{role}."
       user_exists_and_in_org: "User is already a member of sciNote and team %{organization} as %{role}."
       user_exists_invited_to_org: "User was already a member of sciNote - successfully invited to team %{organization} as %{role}."
       user_created: "User succesfully invited to sciNote."


### PR DESCRIPTION
* Allow inviting of unconfirmed user onto more than 1 team;
* Also fix a bug present in current version, where you cannot actually `destroy` users. Issue was caused because when a user gets invited to a team, he/she already receives an `Notification`, whose presence prevented the user from being destroyed. I've added a callback that destroys all `Notification`-s before destroying the `User`.

https://biosistemika.atlassian.net/browse/SCI-676