### PR TITLE
Add an environmental variable to toggle version display in navbar

### DIFF
--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -10,13 +10,19 @@
         <span class="icon-bar"></span>
       </button>
       <a class="navbar-brand" href="<%= root_path %>">
-        <% if Rails.env.production? %>
-          <img src="/images/logo.png" id="logo">
-        <% else %>
+        <%
+        show_version = !Rails.env.production?
+        if ENV['NAVBAR_SHOW_VERSION'].present?
+          show_version = YAML.load(ENV['NAVBAR_SHOW_VERSION'])
+        end
+        %>
+        <% if show_version %>
           <img src="/images/logo.png" class="with-version" id="logo">
           <span class="version">
             <%= Constants::APP_VERSION %>
           </span>
+        <% else %>
+          <img src="/images/logo.png" id="logo">
         <% end %>
       </a>
     </div>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -9,7 +9,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="<%= root_path %>">
+      <%= link_to(root_path, class: 'navbar-brand') do %>
         <%
         show_version = !Rails.env.production?
         if ENV['NAVBAR_SHOW_VERSION'].present?
@@ -17,14 +17,14 @@
         end
         %>
         <% if show_version %>
-          <img src="/images/logo.png" class="with-version" id="logo">
+          <%= image_tag('/images/logo.png', class: 'with-version', id: 'logo') %>
           <span class="version">
             <%= Constants::APP_VERSION %>
           </span>
         <% else %>
-          <img src="/images/logo.png" id="logo">
+          <%= image_tag('/images/logo.png', id: 'logo') %>
         <% end %>
-      </a>
+      <% end %>
     </div>
 
     <% if user_signed_in? %>


### PR DESCRIPTION
The variable is called `NAVBAR_SHOW_VERSION`. If not specified,
it defaults to the current behavior (version is hidden on
`production`, but visible on `development` & `test` environments).

After the merge, don't forget to update the Wiki page with the new variable.