### PR TITLE
fixes compatibility issue on mozilla firefox

### DIFF
--- a/app/assets/javascripts/samples/sample_datatable.js.erb
+++ b/app/assets/javascripts/samples/sample_datatable.js.erb
@@ -1048,13 +1048,14 @@ function changeToEditMode() {
 
           cancelEditMode();
         },
-        error: function(xhr, ajaxOptions, thrownError) {
+        error: function(xhr) {
           dropdownList.sortable('disable');
           $(li).clearFormErrors();
           var msg = $.parseJSON(xhr.responseText);
-          renderFormError(event,
+
+          renderFormError(xhr,
                           $(li).find('.text-edit'),
-                          Object.keys(msg)[0] + ' '+ msg.name.toString());
+                          Object.keys(msg)[0] + ' ' + msg.name.toString());
           var verticalHeight = $(li).offset().top;
           dropdownList.scrollTo(verticalHeight,0);
         }


### PR DESCRIPTION
On Mozilla Firefox v 50.1.0 the error message are not displayed when editing column name.