### PR TITLE
Hotfix 1.6.1

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -146,6 +146,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
       # this must be called after @org variable is defined. Otherwise this
       # variable won't be accessable in view.
       super do |resource|
+        # Set the confirmed_at == created_at IF not using email confirmations
+        unless Rails.configuration.x.enable_email_confirmations
+          resource.update(confirmed_at: resource.created_at)
+        end
+
         if resource.valid? && resource.persisted?
           @org.created_by = resource # set created_by for oraganization
           @org.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -161,11 +161,7 @@ class User < ActiveRecord::Base
 
   # Whether user is active (= confirmed) or not
   def active?
-    if confirmation_required?
-      confirmed_at.present?
-    else
-      invited_by.present? ? invitation_accepted? : true
-    end
+    confirmed_at.present?
   end
 
   def active_status_str

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -186,7 +186,7 @@ class Constants
   #=============================================================================
 
   # Application version
-  APP_VERSION = '1.6.0'.freeze
+  APP_VERSION = '1.6.1'.freeze
 
   TEXT_EXTRACT_FILE_TYPES = [
     'application/pdf',


### PR DESCRIPTION
Set `confirmed_at` to `created_at` when using no
email confirmations and users sign up by themselves.