### PR TITLE
Year difference problems with notifications [SCI-876]

### DIFF
--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,4 +1,6 @@
 class ActivitiesController < ApplicationController
+  include ActivityHelper
+
   before_filter :load_vars
 
   def index
@@ -14,8 +16,8 @@ class ActivitiesController < ApplicationController
     # Whether to hide date labels
     @hide_today = params.include? :from
     @day = @last_activity.present? ?
-      @last_activity.created_at.strftime("%j").to_i :
-      366
+      days_since_1970(@last_activity.created_at) :
+      days_since_1970(DateTime.current + 30.days)
 
     more_url = url_for(activities_url(format: :json,
       from: @activities.last.id))

--- a/app/helpers/activity_helper.rb
+++ b/app/helpers/activity_helper.rb
@@ -10,4 +10,8 @@ module ActivityHelper
     message = message.gsub(/#{activity_title}/, title )
     message.html_safe if message
   end
+
+  def days_since_1970(dt)
+    dt.to_i / 86400
+  end
 end

--- a/app/views/activities/_list.html.erb
+++ b/app/views/activities/_list.html.erb
@@ -1,7 +1,7 @@
 <%
   current_day = days_since_1970(DateTime.current)
 %>
-<% if !hide_today and activities.count > 0 and days_since_1970(activities[0].created_at) == current_day %>
+<% if !hide_today && activities.count > 0 && days_since_1970(activities[0].created_at) == current_day %>
   <li class="text-center activity-date-item">
     <span class="label label-primary">
       <%=t "activities.index.today" %>

--- a/app/views/activities/_list.html.erb
+++ b/app/views/activities/_list.html.erb
@@ -1,7 +1,7 @@
 <%
-  current_day = DateTime.current.strftime('%j').to_i
+  current_day = days_since_1970(DateTime.current)
 %>
-<% if !hide_today and activities.count > 0 and activities[0].created_at.strftime('%j').to_i == current_day %>
+<% if !hide_today and activities.count > 0 and days_since_1970(activities[0].created_at) == current_day %>
   <li class="text-center activity-date-item">
     <span class="label label-primary">
       <%=t "activities.index.today" %>
@@ -9,10 +9,10 @@
   </li>
 <% end %>
 <% activities.each do |activity| %>
-  <% activity_day = activity.created_at.strftime('%j').to_i %>
+  <% activity_day = days_since_1970(activity.created_at) %>
 
   <% if activity_day < current_day and activity_day < day %>
-    <% day = activity.created_at.strftime('%j').to_i %>
+    <% day = days_since_1970(activity.created_at) %>
     <li class="text-center activity-date-item">
       <span class="label label-primary">
         <%= activity.created_at.strftime('%d.%m.%Y') %>

--- a/app/views/my_module_comments/_list.html.erb
+++ b/app/views/my_module_comments/_list.html.erb
@@ -1,10 +1,10 @@
 <% day = 0 %>
-<% current_day = DateTime.current.strftime('%j').to_i %>
+<% current_day = days_since_1970(DateTime.current) %>
 
 <% comments.each do |comment| %>
-  <% comment_day = comment.created_at.strftime('%j').to_i %>
+  <% comment_day = days_since_1970(comment.created_at) %>
   <% if comment_day <= current_day && comment_day > day %>
-    <% day = comment.created_at.strftime('%j').to_i %>
+    <% day = days_since_1970(comment.created_at) %>
     <li class="comment-date-separator">
       <p class="text-center"><%= comment.created_at.strftime('%d.%m.%Y') %></p>
     </li>

--- a/app/views/project_comments/_list.html.erb
+++ b/app/views/project_comments/_list.html.erb
@@ -1,9 +1,9 @@
 <% day = 0 %>
-<% current_day = DateTime.current.strftime('%j').to_i %>
+<% current_day = days_since_1970(DateTime.current) %>
 <% comments.each do |comment| %>
-  <% comment_day = comment.created_at.strftime('%j').to_i %>
+  <% comment_day = days_since_1970(comment.created_at) %>
     <% if comment_day <= current_day && comment_day > day %>
-      <% day = comment.created_at.strftime('%j').to_i %>
+      <% day = days_since_1970(comment.created_at) %>
       <li class="comment-date-separator">
         <p class="text-center"><%= comment.created_at.strftime('%d.%m.%Y') %></p>
       </li>

--- a/app/views/result_comments/_list.html.erb
+++ b/app/views/result_comments/_list.html.erb
@@ -1,10 +1,10 @@
 <% day = 0 %>
-<% current_day = DateTime.current.strftime('%j').to_i %>
+<% current_day = days_since_1970(DateTime.current) %>
 
 <% comments.each do |comment| %>
-  <% comment_day = comment.created_at.strftime('%j').to_i %>
+  <% comment_day = days_since_1970(comment.created_at) %>
   <% if comment_day <= current_day && comment_day > day %>
-    <% day = comment.created_at.strftime('%j').to_i %>
+    <% day = days_since_1970(comment.created_at) %>
     <li class="comment-date-separator">
       <p class="text-center"><%= comment.created_at.strftime('%d.%m.%Y') %></p>
     </li>

--- a/app/views/step_comments/_list.html.erb
+++ b/app/views/step_comments/_list.html.erb
@@ -1,10 +1,10 @@
 <% day = 0 %>
-<% current_day = DateTime.current.strftime('%j').to_i %>
+<% current_day = days_since_1970(DateTime.current) %>
 
 <% comments.each do |comment| %>
-  <% comment_day = comment.created_at.strftime('%j').to_i %>
+  <% comment_day = days_since_1970(comment.created_at) %>
   <% if comment_day <= current_day && comment_day > day %>
-    <% day = comment.created_at.strftime('%j').to_i %>
+    <% day = days_since_1970(comment.created_at) %>
     <li class="comment-date-separator">
       <p class="text-center"><%= comment.created_at.strftime('%d.%m.%Y') %></p>
     </li>


### PR DESCRIPTION
Fix an issue that occured with incorrect sorting of notifications, as well as all 4 types of comments (project, task, step, result), if you had activities/comments from 2 different years (e.g. 2016 and 2017).

Closes [SCI-876](https://biosistemika.atlassian.net/browse/SCI-876).