### PR TITLE
Fix compatibility of fixed samples table header and modal-tooltip [SCI-855]

### DIFF
--- a/app/assets/javascripts/samples/sample_datatable.js.erb
+++ b/app/assets/javascripts/samples/sample_datatable.js.erb
@@ -164,6 +164,7 @@ function dataTableInit() {
         $('#samples-columns-dropdown').removeClass('open');
       });
       // Fix compatibility of fixed table header and column names modal-tooltip
+      // by removing overflow: hidden
       $('.dataTables_scrollHead').css('overflow', '');
     }
   });

--- a/app/assets/javascripts/samples/sample_datatable.js.erb
+++ b/app/assets/javascripts/samples/sample_datatable.js.erb
@@ -163,6 +163,8 @@ function dataTableInit() {
       table.on('mousedown', function() {
         $('#samples-columns-dropdown').removeClass('open');
       });
+      // Fix compatibility of fixed table header and column names modal-tooltip
+      $('.dataTables_scrollHead').css('overflow', '');
     }
   });
 


### PR DESCRIPTION
https://biosistemika.atlassian.net/browse/SCI-855

Datatables Scroller extension add "overflow:hidden" to the header through style attribute which breaks modal-tooltips for columns names. I haven't found way to disable this behavior in Scroller, so just remove this parameter in JS on table fnInitComplete.  