### PR TITLE
Add sample info modal popup to sample smart annotations [SCI-892]

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -28,6 +28,7 @@
 //= require typeahead.bundle.min
 //= require nested_form_fields
 //= require_directory ./sitewide
+//= require datatables
 //= require dataTables.noSearchHidden
 //= require bootstrap-select
 //= require underscore

--- a/app/assets/javascripts/my_modules/protocols.js.erb
+++ b/app/assets/javascripts/my_modules/protocols.js.erb
@@ -1,7 +1,6 @@
 //= require protocols/import_export/import
 //= require protocols/import_export/export
 //= require comments
-//= require datatables
 
 // Currently selected row in "load from protocol" modal
 var selectedRow = null;

--- a/app/assets/javascripts/protocols/index.js
+++ b/app/assets/javascripts/protocols/index.js
@@ -1,6 +1,5 @@
 //= require protocols/import_export/import
 //= require protocols/import_export/export
-//= require datatables
 
 // Global variables
 var rowsSelected = [];

--- a/app/assets/javascripts/samples/sample_datatable.js.erb
+++ b/app/assets/javascripts/samples/sample_datatable.js.erb
@@ -56,9 +56,8 @@ function dataTableInit() {
     }, {
       targets: 2,
       render: function(data, type, row) {
-        return "<a href='#' data-href='" + row.sampleUpdateUrl + "'" +
-                      "class='sample_info' data-toggle='modal'" +
-                      "data-target='#modal-info-sample'>" + data + '</a>';
+        return "<a href='" + row.sampleInfoUrl + "'" +
+                      "class='sample-info-link'>" + data + '</a>';
       }
     }],
     rowCallback: function(row, data) {
@@ -89,12 +88,11 @@ function dataTableInit() {
     fnDrawCallback: function() {
       animateSpinner(this, false);
       changeToViewMode();
-      sampleInfoListener();
       updateButtons();
     },
     preDrawCallback: function() {
       animateSpinner(this);
-      $('.sample_info').off('click');
+      $('.sample-info-link').off('click');
     },
     stateLoadCallback: function(settings) {
       // Send an Ajax request to the server to get the data. Note that
@@ -145,7 +143,6 @@ function dataTableInit() {
       table.on('mousedown', function() {
         $('#samples-columns-dropdown').removeClass('open');
       });
-      sampleInfoListener();
     }
   });
 
@@ -162,8 +159,11 @@ function dataTableInit() {
   });
 
   // Handle click on table cells with checkboxes
-  $('#samples').on('click', 'tbody td, thead th:first-child', function() {
-    $(this).parent().find('input[type="checkbox"]').trigger('click');
+  $('#samples').on('click', 'tbody td, thead th:first-child', function(e) {
+    if (!$(e.target).is('.sample-info-link')) {
+      // Skip if clicking on samples info link
+      $(this).parent().find('input[type="checkbox"]').trigger('click');
+    }
   });
 
   // Handle clicks on checkbox
@@ -319,54 +319,6 @@ function appendSamplesIdToForm(form) {
             .attr('name', 'sample_ids[]')
             .val(rowId)
         );
-    });
-}
-
-//Show sample info
-function sampleInfoListener() {
-    $(".sample_info").on("click", function(e){
-        var that = $(this);
-        $.ajax({
-            method: "GET",
-            url: that.attr("data-href")  + '.json',
-            dataType: "json"
-        }).done(function(xhr, settings, data) {
-            $("body").append($.parseHTML(data.responseJSON.html));
-            $("#modal-info-sample").modal('show',{
-                backdrop: true,
-                keyboard: false,
-            }).on('hidden.bs.modal', function () {
-                $(this).find(".modal-body #sample-info-table").DataTable().destroy();
-                $(this).remove();
-            });
-
-            $('#sample-info-table').DataTable({
-                dom: "RBltpi",
-                stateSave: false,
-                buttons: [],
-                processing: true,
-                colReorder: {
-                    fixedColumnsLeft: 1000000 // Disable reordering
-                },
-                columnDefs: [{
-                    targets: 0,
-                    searchable: false,
-                    orderable: false
-                }],
-                fnDrawCallback: function(settings, json) {
-                    animateSpinner(this, false);
-                },
-                preDrawCallback: function(settings) {
-                    animateSpinner(this);
-                }
-            });
-        }).fail(function(error){
-            // TODO
-        }).always(function(data){
-            // TODO
-        });
-        e.preventDefault();
-        return false;
     });
 }
 

--- a/app/assets/javascripts/samples/samples.js
+++ b/app/assets/javascripts/samples/samples.js
@@ -1,5 +1,3 @@
-//= require datatables
-
 // Create import samples ajax
 $("#modal-import-samples").on("show.bs.modal", function(event) {
     formGroup = $(this).find(".form-group");

--- a/app/assets/javascripts/sitewide/sample_info_modal.js
+++ b/app/assets/javascripts/sitewide/sample_info_modal.js
@@ -1,0 +1,44 @@
+(function() {
+  'use strict';
+
+  $(document).on('click', '.sample-info-link', function(e) {
+    var that = $(this);
+    $.ajax({
+      method: 'GET',
+      url: that.attr('href'),
+      dataType: 'json'
+    }).done(function(xhr, settings, data) {
+      $('body').append($.parseHTML(data.responseJSON.html));
+      $('#modal-info-sample').modal('show', {
+        backdrop: true,
+        keyboard: false
+      }).on('hidden.bs.modal', function() {
+        $(this).find('.modal-body #sample-info-table').DataTable().destroy();
+        $(this).remove();
+      });
+
+      $('#sample-info-table').DataTable({
+        dom: 'RBltpi',
+        stateSave: false,
+        buttons: [],
+        processing: true,
+        colReorder: {
+          fixedColumnsLeft: 1000000 // Disable reordering
+        },
+        columnDefs: [{
+          targets: 0,
+          searchable: false,
+          orderable: false
+        }],
+        fnDrawCallback: function(settings, json) {
+          animateSpinner(this, false);
+        },
+        preDrawCallback: function(settings) {
+          animateSpinner(this);
+        }
+      });
+    });
+    e.preventDefault();
+    return false;
+  });
+})();

--- a/app/assets/javascripts/users/settings/organization.js
+++ b/app/assets/javascripts/users/settings/organization.js
@@ -1,5 +1,3 @@
-//= require datatables
-
 var usersDatatable = null;
 
 // Initialize edit name modal window

--- a/app/datatables/sample_datatable.rb
+++ b/app/datatables/sample_datatable.rb
@@ -111,12 +111,12 @@ class SampleDatatable < AjaxDatatablesRails::Base
         '2': record.name,
         '3': record.sample_type.nil? ? I18n.t('samples.table.no_type') : record.sample_type.name,
         '4': record.sample_group.nil? ?
-        "<span class='glyphicon glyphicon-asterisk'></span> " + I18n.t("samples.table.no_group") :
-        "<span class='glyphicon glyphicon-asterisk' style='color: #{record.sample_group.color}'></span> " + record.sample_group.name,
+          "<span class='glyphicon glyphicon-asterisk'></span> " + I18n.t("samples.table.no_group") :
+          "<span class='glyphicon glyphicon-asterisk' style='color: #{record.sample_group.color}'></span> " + record.sample_group.name,
         "5": I18n.l(record.created_at, format: :full),
-          "6": record.user.full_name,
-          "sampleInfoUrl": Rails.application.routes.url_helpers.edit_sample_path(record.id),
-          "sampleUpdateUrl": Rails.application.routes.url_helpers.sample_path(record.id)
+        "6": record.user.full_name,
+        "sampleInfoUrl": Rails.application.routes.url_helpers.sample_path(record.id),
+        "sampleUpdateUrl": Rails.application.routes.url_helpers.sample_path(record.id)
       }
 
       # Add custom attributes

--- a/app/datatables/sample_datatable.rb
+++ b/app/datatables/sample_datatable.rb
@@ -110,13 +110,13 @@ class SampleDatatable < AjaxDatatablesRails::Base
         '1': assigned_cell(record),
         '2': record.name,
         '3': record.sample_type.nil? ? I18n.t('samples.table.no_type') : record.sample_type.name,
-        '4': record.sample_group.nil? ?
-          "<span class='glyphicon glyphicon-asterisk'></span> " + I18n.t("samples.table.no_group") :
-          "<span class='glyphicon glyphicon-asterisk' style='color: #{record.sample_group.color}'></span> " + record.sample_group.name,
+        '4': sample_group_cell(record),
         "5": I18n.l(record.created_at, format: :full),
         "6": record.user.full_name,
-        "sampleInfoUrl": Rails.application.routes.url_helpers.sample_path(record.id),
-        "sampleUpdateUrl": Rails.application.routes.url_helpers.sample_path(record.id)
+        "sampleInfoUrl":
+          Rails.application.routes.url_helpers.sample_path(record.id),
+        "sampleUpdateUrl":
+          Rails.application.routes.url_helpers.sample_path(record.id)
       }
 
       # Add custom attributes
@@ -135,6 +135,17 @@ class SampleDatatable < AjaxDatatablesRails::Base
     @assigned_samples.include?(record) ?
       "<span class='circle'>&nbsp;</span>" :
       "<span class='circle disabled'>&nbsp;</span>"
+  end
+
+  def sample_group_cell(record)
+    if record.sample_group.nil?
+      "<span class='glyphicon glyphicon-asterisk'></span> " \
+        "#{I18n.t('samples.table.no_group')}"
+    else
+      "<span class='glyphicon glyphicon-asterisk' " \
+        "style='color: #{record.sample_group.color}'></span> " \
+        "#{record.sample_group.name}"
+    end
   end
 
   # Query database for records (this will be later paginated and filtered)

--- a/app/datatables/sample_datatable.rb
+++ b/app/datatables/sample_datatable.rb
@@ -111,11 +111,11 @@ class SampleDatatable < AjaxDatatablesRails::Base
         '2': record.name,
         '3': record.sample_type.nil? ? I18n.t('samples.table.no_type') : record.sample_type.name,
         '4': sample_group_cell(record),
-        "5": I18n.l(record.created_at, format: :full),
-        "6": record.user.full_name,
-        "sampleInfoUrl":
+        '5': I18n.l(record.created_at, format: :full),
+        '6': record.user.full_name,
+        'sampleInfoUrl':
           Rails.application.routes.url_helpers.sample_path(record.id),
-        "sampleUpdateUrl":
+        'sampleUpdateUrl':
           Rails.application.routes.url_helpers.sample_path(record.id)
       }
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -100,11 +100,9 @@ module ApplicationHelper
         sample = Sample.find_by_id(match[3].base62_decode)
         if sample
           "<span class='glyphicon glyphicon-tint'></span> " \
-          "#{link_to sample.name,
-                     samples_project_path(sample
-                                          .organization
-                                          .projects
-                                          .first)}"
+          "#{link_to(sample.name,
+                     sample_path(sample.id),
+                     class: 'sample-info-link')}"
         else
           "<span class='glyphicon glyphicon-tint'></span> " \
           "#{match[1]} #{t'atwho.res.deleted'}"

--- a/app/views/samples/_info_sample_modal.html.erb
+++ b/app/views/samples/_info_sample_modal.html.erb
@@ -1,4 +1,3 @@
-
 <div class="modal fade" id="modal-info-sample" tabindex="-1" role="dialog" aria-labelledby="myModalLabel">
   <div class="modal-dialog" role="document">
     <div class="modal-content">


### PR DESCRIPTION
This MR also loads `datatables.js` globally (as it's required by
the modal), so I removed it everywhere in code, and it shouldn't
be used anymore (e.g. `//= require datatables`).

Closes [SCI-892](https://biosistemika.atlassian.net/browse/SCI-892).