### PR TITLE
Add Deface checking of environmental variables

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,6 +65,8 @@ Rails.application.configure do
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
 
+  config.deface.enabled = ENV['DEFACE_ENABLED'] == 'true'
+
   # Enable first-time tutorial for users signing in the sciNote for
   # the first time.
   config.x.enable_tutorial = ENV['ENABLE_TUTORIAL'] == 'true'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
 
   # Enable/disable Deface
-  config.deface.enabled = ENV['DEFACE_ENABLED'] == 'true'
+  config.deface.enabled = ENV['DEFACE_ENABLED'] != 'false'
 
   # Enable first-time tutorial for users signing in the sciNote for
   # the first time.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -65,6 +65,7 @@ Rails.application.configure do
   # Raises error for missing translations
   config.action_view.raise_on_missing_translations = true
 
+  # Enable/disable Deface
   config.deface.enabled = ENV['DEFACE_ENABLED'] == 'true'
 
   # Enable first-time tutorial for users signing in the sciNote for

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,7 +98,7 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Disable deface if neccesary
+  # Enable/disable Deface
   config.deface.enabled = ENV['DEFACE_ENABLED'] == 'true'
 
   # Enable first-time tutorial for users signing in the sciNote for

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,7 +99,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable/disable Deface
-  config.deface.enabled = ENV['DEFACE_ENABLED'] == 'true'
+  config.deface.enabled = ENV['DEFACE_ENABLED'] != 'false'
 
   # Enable first-time tutorial for users signing in the sciNote for
   # the first time.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -98,6 +98,9 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
+  # Disable deface if neccesary
+  config.deface.enabled = ENV['DEFACE_ENABLED'] == 'true'
+
   # Enable first-time tutorial for users signing in the sciNote for
   # the first time.
   config.x.enable_tutorial = ENV['ENABLE_TUTORIAL'] != 'false'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -65,6 +65,9 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Enable/disable Deface
+  config.deface.enabled = ENV['DEFACE_ENABLED'] == 'true'
+
   # Enable first-time tutorial for users signing in the sciNote for
   # the first time.
   config.x.enable_tutorial = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,7 +66,7 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # Enable/disable Deface
-  config.deface.enabled = ENV['DEFACE_ENABLED'] == 'true'
+  config.deface.enabled = ENV['DEFACE_ENABLED'] != 'false'
 
   # Enable first-time tutorial for users signing in the sciNote for
   # the first time.


### PR DESCRIPTION
This should fix the issue with Deface views not getting properly rendered on Heroku.

If no such env. variable is present, the Deface enabled defaults to `true`, so it should keep being the way it is on development environments.