### PR TITLE
Fix sample type groups edit color script [SCI-1078]

### DIFF
--- a/app/assets/javascripts/samples/sample_types_groups.js
+++ b/app/assets/javascripts/samples/sample_types_groups.js
@@ -45,7 +45,6 @@
           destroySampleTypeGroup();
           initSampleColorPicker(newLi);
           appendCarretToColorPickerDropdown();
-          editSampleGroupColor();
           editSampleGroupForm();
         }
       });
@@ -111,17 +110,6 @@
     });
   }
 
-  function editSampleGroupColor() {
-    $('.edit_sample_group a.color-btn').off();
-    $('.edit_sample_group a.color-btn').on('click', function() {
-      var color = $(this).attr('data-value');
-      var form = $(this).closest('form');
-      $('select[name="sample_group[color]"]')
-        .val(color);
-      form.submit();
-    });
-  }
-
   function bindNewSampleGroupAction() {
     $('#new_sample_group').off();
     $('#new_sample_group').bind('ajax:success', function(ev, data) {
@@ -131,7 +119,6 @@
       $(li).insertAfter('.new-resource-form');
       initSampleColorPicker(li);
       appendCarretToColorPickerDropdown();
-      editSampleGroupColor();
       editSampleGroupForm();
       destroySampleTypeGroup();
       $('#new_sample_group').clearFormErrors();
@@ -194,7 +181,6 @@
           destroySampleTypeGroup();
           initSampleColorPicker(newLi);
           appendCarretToColorPickerDropdown();
-          editSampleGroupColor();
 
           $('#edit_sample_group_' + data.id)
             .find('[name="sample_group[name]"]')
@@ -209,7 +195,6 @@
             destroySampleTypeGroup();
             initSampleColorPicker(newLi);
             appendCarretToColorPickerDropdown();
-            editSampleGroupColor();
           }).bind('ajax:error', function(ev, error){
             $(this).clearFormErrors();
             var msg = $.parseJSON(error.responseText);
@@ -225,16 +210,42 @@
   function initSampleGroupColor() {
     var elements = $('.edit-sample-group-color');
     _.each(elements, function(el) {
-      var color = $(el).closest('[data-color]')
-                       .attr('data-color');
-      $(el).colorselector('setColor', color);
+      initSampleColorPicker(el);
     });
   }
 
   function initSampleColorPicker(el) {
-    var element = $(el).find('.edit-sample-group-color');
+    var element;
+    if ($(el).is('.edit-sample-group-color')) {
+      element = $(el);
+    } else {
+      element = $(el).find('.edit-sample-group-color');
+    }
     var color = $(element).closest('[data-color]').attr('data-color');
     $(element).colorselector('setColor', color);
+
+    // Bind on buttons
+    var btns = $(element).closest('.edit_sample_group').find('a.color-btn');
+    btns.off();
+    btns.on('click', function() {
+      var color = $(this).attr('data-value');
+      $('select[name="sample_group[color]"]').val(color);
+
+      var form = $(this).closest('form');
+      form
+      .off('ajax:success ajax:error')
+      .on('ajax:success', function() {
+      })
+      .on('ajax:error', function() {
+        form
+        .find('select')
+        .colorselector(
+          'setColor',
+          form.closest('[data-color]').attr('data-color')
+        );
+      });
+      form.submit();
+    });
   }
 
 /**
@@ -254,7 +265,6 @@
     editSampleTypeForm();
     destroySampleTypeGroup();
     editSampleGroupForm();
-    editSampleGroupColor();
     initSampleGroupColor();
     bindNewSampleGroupAction();
     appendCarretToColorPickerDropdown();


### PR DESCRIPTION
Closes [SCI-1078](https://biosistemika.atlassian.net/browse/SCI-1078).

Is a fix on its own (editing colors for sample groups didn't work properly before), but was fixed as part of [this MR](http://gitlab.biosistemika.com/scinote/electronic_signatures/merge_requests/10).