### PR TITLE
Whitelist application/zip file type in paperclip for some .xlsx files [SCI-1166]

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -202,6 +202,7 @@ module Paperclip
         )) ||
         # Spreadsheet application
         (Set[content_type, content_types_from_name].subset? Set.new %w(
+          application/zip
           application/vnd.ms-office
           application/vnd.ms-excel
           application/vnd.openxmlformats-officedocument.spreadsheetml.sheet


### PR DESCRIPTION
https://biosistemika.atlassian.net/browse/SCI-1166

Some .xlsx files are detected as application/zip