### PR TITLE
Disables annimateSpiner in result assets actions

### DIFF
--- a/app/assets/javascripts/results/result_assets.js
+++ b/app/assets/javascripts/results/result_assets.js
@@ -17,7 +17,7 @@ $("#new-result-asset").on("ajax:success", function(e, data) {
 });
 
 $("#new-result-asset").on("ajax:error", function(e, xhr, status, error) {
-  // TODO
+  animateSpinner(null, false);
 });
 
 // Edit result asset button behaviour
@@ -46,7 +46,7 @@ function applyEditResultAssetCallback() {
   });
 
   $(".edit-result-asset").on("ajax:error", function(e, xhr, status, error) {
-  // TODO
+    animateSpinner(null, false);
   });
 }
 
@@ -75,6 +75,7 @@ function formAjaxResultAsset($form) {
     else
       errors = data.responseJSON.errors;
     $form.renderFormErrors("result", errors, true, e);
+    animateSpinner(null, false);
   });
 }
 


### PR DESCRIPTION
Here I have disabled the annimateSpinner in result_assets.js where the ajax error callback happend. Hopefully it will fix the spinner issue. !!!You can't reproduce this locally!!!

https://biosistemika.atlassian.net/browse/SCI-1129