### PR TITLE
Fixes DEPRECATION WARNING-s for Rails 5.1.2 [SCI-1427]

### DIFF
--- a/app/models/asset_text_datum.rb
+++ b/app/models/asset_text_datum.rb
@@ -8,7 +8,7 @@ class AssetTextDatum < ApplicationRecord
   after_save :update_ts_index
 
   def update_ts_index
-    if data_changed?
+    if saved_change_to_data?
       sql = "UPDATE asset_text_data " +
             "SET data_vector = to_tsvector(data) " +
             "WHERE id = " + Integer(id).to_s

--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -12,7 +12,8 @@ class MyModule < ApplicationRecord
   validates :description, length: { maximum: Constants::TEXT_MAX_LENGTH }
   validates :x, :y, :workflow_order, presence: true
   validates :experiment, presence: true
-  validates :my_module_group, presence: true, if: "!my_module_group_id.nil?"
+  validates :my_module_group, presence: true,
+            if: proc { |mm| !mm.my_module_group_id.nil? }
 
   belongs_to :created_by,
              foreign_key: 'created_by_id',

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -669,9 +669,9 @@ class Protocol < ApplicationRecord
 
   def update_linked_children
     # Increment/decrement the parent's nr of linked children
-    if self.parent_id_changed?
-      if self.parent_id_was != nil
-        p = Protocol.find_by_id(self.parent_id_was)
+    if self.saved_change_to_parent_id?
+      if self.parent_id_before_last_save != nil
+        p = Protocol.find_by_id(self.parent_id_before_last_save)
         p.record_timestamps = false
         p.decrement!(:nr_of_linked_children)
       end

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -669,9 +669,9 @@ class Protocol < ApplicationRecord
 
   def update_linked_children
     # Increment/decrement the parent's nr of linked children
-    if self.saved_change_to_parent_id?
-      if self.parent_id_before_last_save != nil
-        p = Protocol.find_by_id(self.parent_id_before_last_save)
+    if saved_change_to_parent_id?
+      unless parent_id_before_last_save.nil?
+        p = Protocol.find_by_id(parent_id_before_last_save)
         p.record_timestamps = false
         p.decrement!(:nr_of_linked_children)
       end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -9,7 +9,7 @@ class Step < ApplicationRecord
   validates :position, presence: true
   validates :completed, inclusion: { in: [true, false] }
   validates :user, :protocol, presence: true
-  validates :completed_on, presence: true, if: "completed?"
+  validates :completed_on, presence: true, if: proc { |s| s.completed? }
 
   belongs_to :user, inverse_of: :steps, optional: true
   belongs_to :last_modified_by,

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -120,7 +120,7 @@ class Table < ApplicationRecord
   end
 
   def update_ts_index
-    if contents_changed?
+    if saved_change_to_contents?
       sql = "UPDATE tables " +
             "SET data_vector = " +
             "to_tsvector(substring(encode(contents::bytea, 'escape'), 9)) " +


### PR DESCRIPTION
This just fixes the warning messages occured during click-through
of the application. I didn't systematically search code for all
potential problems (I couldn't find the list of all deprecations
anyway).

Closes [SCI-1427](https://biosistemika.atlassian.net/browse/SCI-1427).