### PR TITLE
chore: Add EditorConfig preference file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# Root EditorConfig preference file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.rb]
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.{js,jsx}]
+charset = utf-8
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
EditorConfig is a tool (editor extension) that allows developers to
configure the indent style / size for various files in the codebase.
It is useful to uniformly introduce spacing for various filetypes.
In our case it is used for .js/.jsx and .rb files to keep indents
consistent. It is also configured to insert a final new line on every
file we create/edit. This is helpful for Git Diffs.

Learn more about EditorConfig: http://editorconfig.org/

Learn more about the history behind new lines at EOF:

- https://robots.thoughtbot.com/no-newline-at-end-of-file
- https://unix.stackexchange.com/questions/18743/whats-the-point-in-adding-a-new-line-to-the-end-of-a-file
- https://stackoverflow.com/questions/5813311/no-newline-at-end-of-file

Signed-off-by: Adrian Oprea <adrian@oprea.rocks>