### PR TITLE
Fix Wicked PDF version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,7 @@ gem 'commit_param_routing' # Enables different submit actions in the same form t
 gem 'kaminari'
 gem 'i18n-js', '~> 3.0' # Localization in javascript files
 gem 'roo', '~> 2.7.1' # Spreadsheet parser
-gem 'wicked_pdf'
+gem 'wicked_pdf', '~> 1.0.6'
 gem 'silencer' # Silence certain Rails logs
 gem 'wkhtmltopdf-heroku'
 gem 'remotipart', '~> 1.2' # Async file uploads

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -448,7 +448,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
     whacamole (1.2.0)
-    wicked_pdf (1.1.0)
+    wicked_pdf (1.0.6)
     wkhtmltopdf-heroku (2.12.4.0)
     xpath (2.1.0)
       nokogiri (~> 1.3)
@@ -546,7 +546,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   underscore-rails
   whacamole
-  wicked_pdf
+  wicked_pdf (~> 1.0.6)
   wkhtmltopdf-heroku
   yomu
 


### PR DESCRIPTION
For production environment, the `wicked_pdf` Gem version needs to be locked to `~> 1.0.6`, because the newer versions removed one of the modules (`WickedPdfHelper`) we are overriding/decorating.
