### PR TITLE
A red error messagge is now displayed when not selecting protocol [SCI-1993]

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -601,8 +601,17 @@ class ProtocolsController < ApplicationController
   def protocolsio_import_create
     @protocolsio_too_big = false
     @protocolsio_invalid_file = false
+    @protocolsio_no_file = false
+    if params[:json_file].nil?
+      @protocolsio_no_file = true
+      respond_to do |format|
+        format.js {}
+      end
+      return 0 # return 0 stops the rest of the controller code from executing
+    end
     extension = File.extname(params[:json_file].path)
     file_size = File.size(params[:json_file].path)
+
     if extension != '.txt' && extension != '.json'
       @protocolsio_invalid_file = true
       respond_to do |format|

--- a/app/views/protocols/import_export/_import_json_protocol_modal.html.erb
+++ b/app/views/protocols/import_export/_import_json_protocol_modal.html.erb
@@ -18,6 +18,7 @@
       <div class="modal-body">
 
         <%= file_field_tag 'json_file', accept: '.txt,.json' %>
+        <div id="pio_no_file_error_span"></div>
 
       </div>
       <div class="modal-footer">

--- a/app/views/protocols/protocolsio_import_create.js.erb
+++ b/app/views/protocols/protocolsio_import_create.js.erb
@@ -1,4 +1,6 @@
-
+$('#modal-import-json-protocol').on('hidden.bs.modal', function () {
+    $('#pio_no_file_error_span').empty();
+})
 <% if @protocolsio_too_big %>
 $('#modal-import-json-protocol').modal('hide');
 HelperModule.flashAlertMsg(' <%= t('my_modules.protocols.load_from_file_size_error',
@@ -6,6 +8,10 @@ HelperModule.flashAlertMsg(' <%= t('my_modules.protocols.load_from_file_size_err
 <% elsif @protocolsio_invalid_file %>
 $('#modal-import-json-protocol').modal('hide');
 HelperModule.flashAlertMsg(' <%= t('my_modules.protocols.load_from_file_invalid_error') %>','danger');
+<% elsif @protocolsio_no_file %>
+<%# no file alert code goes here color: #a94442 %>
+$('#pio_no_file_error_span').html('<span class="help-block" style="color:#a94442"> <%= t('teams.parse_sheet.errors.no_file_selected') %></span>');
+<% @protocolsio_no_file = false %>
 <% else %>
   $('#modal-import-json-protocol').modal('hide');
       <% if remotipart_submitted? %> <%# a workaround to a bug with remotipart, that caused alot of headache, courtesy of github.com/dhampik %>

--- a/app/views/protocols/protocolsio_import_create.js.erb
+++ b/app/views/protocols/protocolsio_import_create.js.erb
@@ -9,8 +9,7 @@ HelperModule.flashAlertMsg(' <%= t('my_modules.protocols.load_from_file_size_err
 $('#modal-import-json-protocol').modal('hide');
 HelperModule.flashAlertMsg(' <%= t('my_modules.protocols.load_from_file_invalid_error') %>','danger');
 <% elsif @protocolsio_no_file %>
-<%# no file alert code goes here color: #a94442 %>
-$('#pio_no_file_error_span').html('<span class="help-block" style="color:#a94442"> <%= t('teams.parse_sheet.errors.no_file_selected') %></span>');
+$('#pio_no_file_error_span').addClass('has-error').html('<span class="help-block"> <%= t('teams.parse_sheet.errors.no_file_selected') %></span>');
 <% @protocolsio_no_file = false %>
 <% else %>
   $('#modal-import-json-protocol').modal('hide');


### PR DESCRIPTION
when no protocol.io file is selected, but submit button is pressed, it returns a red error on the modal,  like in the repositories modal. after modal is closed, the error dissapears.