### PR TITLE
Changed sub protocol name length limit to limit of protocol titles on scinote [SCI-1995]

### DIFF
--- a/app/helpers/protocols_io_helper.rb
+++ b/app/helpers/protocols_io_helper.rb
@@ -175,9 +175,13 @@ module ProtocolsIoHelper
       else
         ' , '
       end
-    output_string += prepare_for_view(
-      attribute_text, ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_SMALL
-    )
+    if attribute_name == 'protocol_name'
+      output_string += pio_eval_title_len(attribute_text)
+    else
+      output_string += prepare_for_view(
+        attribute_text, ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_SMALL
+      )
+    end
     output_string
   end
 

--- a/app/views/protocols/import_export/_import_json_protocol_s_desc.html.erb
+++ b/app/views/protocols/import_export/_import_json_protocol_s_desc.html.erb
@@ -98,7 +98,7 @@
             <% when '18'%>
               <br>
               <strong><%= t('protocols.protocols_io_import.preview.sub_prot') %></strong>
-              <%= prepare_for_view(key['source_data']['protocol_name'],ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_SMALL,'table').html_safe %>
+              <%= pio_eval_title_len(sanitize_input(key['source_data']['protocol_name'])).html_safe %>
               <br>
               <%= t('protocols.protocols_io_import.preview.auth') %>
               <%= prepare_for_view(key['source_data']['full_name'],ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_SMALL,'table').html_safe %>


### PR DESCRIPTION
When a sub protocol is attached in steps, before it counted towards total step character length, but since a sub protocol title is only useful in its entirety, it is now counted towards the scinote max title limit length (255 characters)