### PR TITLE
Fix canaid initializer so it only uses required Gems' permissions

### DIFF
--- a/config/initializers/canaid.rb
+++ b/config/initializers/canaid.rb
@@ -12,7 +12,7 @@ Canaid.configure do |config|
                 .eager_load_paths
                 .select { |p| p.ends_with?('permissions') }
                 .first
-    continue unless full_path
+    next unless full_path
     res = rx.match(full_path)
     config.permissions_paths << "#{res[1]}/**/*.rb" if res && res.length > 1
   end

--- a/config/initializers/canaid.rb
+++ b/config/initializers/canaid.rb
@@ -1,4 +1,19 @@
 Canaid.configure do |config|
+  include AddonsHelper
+
   config.permissions_paths << 'app/permissions/**/*.rb'
-  config.permissions_paths << 'addons/**/app/permissions/**/*.rb'
+
+  # Include the included addons' permissions folders
+  rx = %r{^.*(addons/.*/app/permissions)$}
+  list_all_addons.each do |addon|
+    full_path = addon::Engine
+                .instance
+                .config
+                .eager_load_paths
+                .select { |p| p.ends_with?('permissions') }
+                .first
+    continue unless full_path
+    res = rx.match(full_path)
+    config.permissions_paths << "#{res[1]}/**/*.rb" if res && res.length > 1
+  end
 end


### PR DESCRIPTION
This should make sure that other addons that are located in
/addons folder, but not actually required by the core,
do not cause trouble.