### PR TITLE
Remove component loader (so builds pass)

### DIFF
--- a/app/javascript/src/components/Navigation/index.jsx
+++ b/app/javascript/src/components/Navigation/index.jsx
@@ -16,10 +16,11 @@ import SearchDropdown from "./components/SearchDropdown";
 import NotificationsDropdown from "./components/NotificationsDropdown";
 import InfoDropdown from "./components/InfoDropdown";
 import UserAccountDropdown from "./components/UserAccountDropdown";
-import withExtras from 'react-hijack';
-import addonsConfig from '../../componentLoader/config';
-import massageConfiguration from '../../componentLoader/massageConfiguration';
-import componentLoader from '../../componentLoader';
+// Ignore so Heroku builds pass
+//import withExtras from 'react-hijack';
+//import addonsConfig from '../../componentLoader/config';
+//import massageConfiguration from '../../componentLoader/massageConfiguration';
+//import componentLoader from '../../componentLoader';
 
 const StyledNavbar = styled(Navbar)`
   background-color: ${WHITE_COLOR};
@@ -151,9 +152,12 @@ Navigation.propTypes = {
 
 // Map the states from store to component props
 const mapStateToProps = ({ current_team }) => ({ current_team });
-const NavigationWithExtras = withExtras({
-  identifier: 'navigation',
-  config: massageConfiguration(addonsConfig, 'navigation'),
-}, componentLoader)(Navigation);
 
-export default connect(mapStateToProps)(NavigationWithExtras);
+// Ignore so Heroku builds pass
+//const NavigationWithExtras = withExtras({
+//  identifier: 'navigation',
+//  config: massageConfiguration(addonsConfig, 'navigation'),
+//}, componentLoader)(Navigation);
+//
+//export default connect(mapStateToProps)(NavigationWithExtras);
+export default connect(mapStateToProps)(Navigation);

--- a/config/initializers/addon_loader.rb
+++ b/config/initializers/addon_loader.rb
@@ -1,31 +1,32 @@
-TARGET_ROOT = "#{Dir.pwd}/app/javascript/src/componentLoader".freeze
-COMPONENTS_ROOT = "#{TARGET_ROOT}/components".freeze
-UBER_CONFIG_PATH = "#{TARGET_ROOT}/availableAddons.js".freeze
-
-begin
-# clear previous build
-FileUtils.rm_f Dir.glob("#{COMPONENTS_ROOT}/*")
-FileUtils.rm_f Dir.glob(UBER_CONFIG_PATH)
-File.new(UBER_CONFIG_PATH, 'w+')
-enabled_addons = []
-
-Dir.foreach('addons/') do |path|
-  addons_client_root = "addons/#{path}/client"
-  next unless Dir.exist? addons_client_root
-  File.open(UBER_CONFIG_PATH, 'w') do |file|
-    file.puts("import #{path} from \'./components/#{path}/config.js\';")
-  end
-  enabled_addons << "#{path}"
-  File.symlink("#{Dir.pwd}/#{addons_client_root}", "#{COMPONENTS_ROOT}/#{path}")
-end
-
-File.open(UBER_CONFIG_PATH, 'a') do |file|
-  file.puts("export default { #{enabled_addons.join(", ").gsub(/\"/, '')} };")
-end
-
-# handles error on the platforms that does not support symlink
-# http://ruby-doc.org/core-2.2.0/File.html#symlink-method
-rescue
-  puts '[sciNote] Unable to load React components from addons!'
-  puts '[sciNote] Your system does not support symlink!'
-end
+# Ignoring so Heroku builds pass
+#TARGET_ROOT = "#{Dir.pwd}/app/javascript/src/componentLoader".freeze
+#COMPONENTS_ROOT = "#{TARGET_ROOT}/components".freeze
+#UBER_CONFIG_PATH = "#{TARGET_ROOT}/availableAddons.js".freeze
+#
+#begin
+## clear previous build
+#FileUtils.rm_f Dir.glob("#{COMPONENTS_ROOT}/*")
+#FileUtils.rm_f Dir.glob(UBER_CONFIG_PATH)
+#File.new(UBER_CONFIG_PATH, 'w+')
+#enabled_addons = []
+#
+#Dir.foreach('addons/') do |path|
+#  addons_client_root = "addons/#{path}/client"
+#  next unless Dir.exist? addons_client_root
+#  File.open(UBER_CONFIG_PATH, 'w') do |file|
+#    file.puts("import #{path} from \'./components/#{path}/config.js\';")
+#  end
+#  enabled_addons << "#{path}"
+#  File.symlink("#{Dir.pwd}/#{addons_client_root}", "#{COMPONENTS_ROOT}/#{path}")
+#end
+#
+#File.open(UBER_CONFIG_PATH, 'a') do |file|
+#  file.puts("export default { #{enabled_addons.join(", ").gsub(/\"/, '')} };")
+#end
+#
+## handles error on the platforms that does not support symlink
+## http://ruby-doc.org/core-2.2.0/File.html#symlink-method
+#rescue
+#  puts '[sciNote] Unable to load React components from addons!'
+#  puts '[sciNote] Your system does not support symlink!'
+#end

--- a/config/initializers/load_addons_specs.rb
+++ b/config/initializers/load_addons_specs.rb
@@ -1,47 +1,46 @@
-# Ignoring so Heroku builds pass
-#require 'singleton'
-#
-#class AddonsSpecLoader
-#  include Singleton
-#  include AddonsHelper
-#
-#  # rspec will recognise symlinks in the second run
-#  def mount
-#    FileUtils.rm_f Dir.glob("#{Dir.pwd}/spec/addons/*")
-#    available_addons.each do |addon|
-#      specs_path = "addons/#{addon}/spec"
-#      next unless Dir.exist? specs_path
-#      File.symlink("#{Dir.pwd}/#{specs_path}",
-#                   "#{Dir.pwd}/spec/addons/#{addon}")
-#    end
-#  end
-#
-#  # cucumber cannot resolve path with symlinks so we copy files from addons
-#  def copy_to_features
-#    FileUtils.rm_f Dir.glob("#{Dir.pwd}/features/addons/*")
-#    available_addons.each do |addon|
-#      feature_path = "addons/#{addon}/features"
-#      next unless Dir.exist? feature_path
-#      FileUtils.copy_entry("#{Dir.pwd}/#{feature_path}",
-#                           "#{Dir.pwd}/features/addons/#{addon}")
-#    end
-#  end
-#
-#  private
-#
-#  def available_addons
-#    list_all_addons.map { |addon| addon.to_s.split('::').last.underscore }
-#  end
-#end
-#
-#if ENV['RAILS_ENV'].in? %w(test development)
-#  begin
-#    puts '[sciNote] Generating symlinks for addons!'
-#    puts '[sciNote] Copying features from addons!'
-#    AddonsSpecLoader.instance.mount
-#    AddonsSpecLoader.instance.copy_to_features
-#  rescue
-#    puts '[sciNote] Unable to load specs from addons!'
-#    puts '[sciNote] Your system does not support symlink!'
-#  end
-#end
+require 'singleton'
+
+class AddonsSpecLoader
+  include Singleton
+  include AddonsHelper
+
+  # rspec will recognise symlinks in the second run
+  def mount
+    FileUtils.rm_f Dir.glob("#{Dir.pwd}/spec/addons/*")
+    available_addons.each do |addon|
+      specs_path = "addons/#{addon}/spec"
+      next unless Dir.exist? specs_path
+      File.symlink("#{Dir.pwd}/#{specs_path}",
+                   "#{Dir.pwd}/spec/addons/#{addon}")
+    end
+  end
+
+  # cucumber cannot resolve path with symlinks so we copy files from addons
+  def copy_to_features
+    FileUtils.rm_f Dir.glob("#{Dir.pwd}/features/addons/*")
+    available_addons.each do |addon|
+      feature_path = "addons/#{addon}/features"
+      next unless Dir.exist? feature_path
+      FileUtils.copy_entry("#{Dir.pwd}/#{feature_path}",
+                           "#{Dir.pwd}/features/addons/#{addon}")
+    end
+  end
+
+  private
+
+  def available_addons
+    list_all_addons.map { |addon| addon.to_s.split('::').last.underscore }
+  end
+end
+
+if ENV['RAILS_ENV'].in? %w(test development)
+  begin
+    puts '[sciNote] Generating symlinks for addons!'
+    puts '[sciNote] Copying features from addons!'
+    AddonsSpecLoader.instance.mount
+    AddonsSpecLoader.instance.copy_to_features
+  rescue
+    puts '[sciNote] Unable to load specs from addons!'
+    puts '[sciNote] Your system does not support symlink!'
+  end
+end

--- a/config/initializers/load_addons_specs.rb
+++ b/config/initializers/load_addons_specs.rb
@@ -1,46 +1,47 @@
-require 'singleton'
-
-class AddonsSpecLoader
-  include Singleton
-  include AddonsHelper
-
-  # rspec will recognise symlinks in the second run
-  def mount
-    FileUtils.rm_f Dir.glob("#{Dir.pwd}/spec/addons/*")
-    available_addons.each do |addon|
-      specs_path = "addons/#{addon}/spec"
-      next unless Dir.exist? specs_path
-      File.symlink("#{Dir.pwd}/#{specs_path}",
-                   "#{Dir.pwd}/spec/addons/#{addon}")
-    end
-  end
-
-  # cucumber cannot resolve path with symlinks so we copy files from addons
-  def copy_to_features
-    FileUtils.rm_f Dir.glob("#{Dir.pwd}/features/addons/*")
-    available_addons.each do |addon|
-      feature_path = "addons/#{addon}/features"
-      next unless Dir.exist? feature_path
-      FileUtils.copy_entry("#{Dir.pwd}/#{feature_path}",
-                           "#{Dir.pwd}/features/addons/#{addon}")
-    end
-  end
-
-  private
-
-  def available_addons
-    list_all_addons.map { |addon| addon.to_s.split('::').last.underscore }
-  end
-end
-
-if ENV['RAILS_ENV'].in? %w(test development)
-  begin
-    puts '[sciNote] Generating symlinks for addons!'
-    puts '[sciNote] Copying features from addons!'
-    AddonsSpecLoader.instance.mount
-    AddonsSpecLoader.instance.copy_to_features
-  rescue
-    puts '[sciNote] Unable to load specs from addons!'
-    puts '[sciNote] Your system does not support symlink!'
-  end
-end
+# Ignoring so Heroku builds pass
+#require 'singleton'
+#
+#class AddonsSpecLoader
+#  include Singleton
+#  include AddonsHelper
+#
+#  # rspec will recognise symlinks in the second run
+#  def mount
+#    FileUtils.rm_f Dir.glob("#{Dir.pwd}/spec/addons/*")
+#    available_addons.each do |addon|
+#      specs_path = "addons/#{addon}/spec"
+#      next unless Dir.exist? specs_path
+#      File.symlink("#{Dir.pwd}/#{specs_path}",
+#                   "#{Dir.pwd}/spec/addons/#{addon}")
+#    end
+#  end
+#
+#  # cucumber cannot resolve path with symlinks so we copy files from addons
+#  def copy_to_features
+#    FileUtils.rm_f Dir.glob("#{Dir.pwd}/features/addons/*")
+#    available_addons.each do |addon|
+#      feature_path = "addons/#{addon}/features"
+#      next unless Dir.exist? feature_path
+#      FileUtils.copy_entry("#{Dir.pwd}/#{feature_path}",
+#                           "#{Dir.pwd}/features/addons/#{addon}")
+#    end
+#  end
+#
+#  private
+#
+#  def available_addons
+#    list_all_addons.map { |addon| addon.to_s.split('::').last.underscore }
+#  end
+#end
+#
+#if ENV['RAILS_ENV'].in? %w(test development)
+#  begin
+#    puts '[sciNote] Generating symlinks for addons!'
+#    puts '[sciNote] Copying features from addons!'
+#    AddonsSpecLoader.instance.mount
+#    AddonsSpecLoader.instance.copy_to_features
+#  rescue
+#    puts '[sciNote] Unable to load specs from addons!'
+#    puts '[sciNote] Your system does not support symlink!'
+#  end
+#end

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "react-data-grid": "^2.0.2",
     "react-document-title": "^2.0.3",
     "react-dom": "15.6.1",
-//    "react-hijack": "biosistemika/react-hijack#2.0.1", Ignoring so Heroku builds pass
     "react-intl": "^2.3.0",
     "react-intl-redux": "^0.6.0",
     "react-moment": "^0.6.4",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "react-data-grid": "^2.0.2",
     "react-document-title": "^2.0.3",
     "react-dom": "15.6.1",
-    "react-hijack": "biosistemika/react-hijack#2.0.1",
+//    "react-hijack": "biosistemika/react-hijack#2.0.1", Ignoring so Heroku builds pass
     "react-intl": "^2.3.0",
     "react-intl-redux": "^0.6.0",
     "react-moment": "^0.6.4",


### PR DESCRIPTION
This of course means that the addons cannot hijack React components into core as of right now.