### PR TITLE
Fixed tables getting cut when certain attributes are at max length [SCI-1834]

### DIFF
--- a/app/helpers/protocols_io_helper.rb
+++ b/app/helpers/protocols_io_helper.rb
@@ -64,7 +64,6 @@ module ProtocolsIoHelper
       )
       tables[table_counter.to_s]['name'] = nil
     end
-    # return string_without_tables, tables
     return tables, string_without_tables
   end
 
@@ -193,7 +192,8 @@ module ProtocolsIoHelper
         br +
         prepare_for_view(
           iterating_key,
-          ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_SMALL
+          ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_SMALL,
+          'table'
           ) +
         br
       else
@@ -214,7 +214,9 @@ module ProtocolsIoHelper
       append =
         t('protocols.protocols_io_import.comp_append.expected_result') +
         prepare_for_view(
-          iterating_key, ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_SMALL
+          iterating_key,
+          ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_SMALL,
+          'table'
         ) +
         '<br>'
       return append
@@ -250,7 +252,8 @@ module ProtocolsIoHelper
         '</strong>' +
         prepare_for_view(
           json_hash['description'],
-          ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_MEDIUM
+          ProtocolsIoHelper::PIO_ELEMENT_RESERVED_LENGTH_MEDIUM,
+          'table'
         ).html_safe
     else
       description_string =

--- a/app/helpers/protocols_io_helper.rb
+++ b/app/helpers/protocols_io_helper.rb
@@ -356,14 +356,11 @@ module ProtocolsIoHelper
     shortened_string, unshortened_tables_string = protocols_io_fill_desc(
       original_json
     )
-    shortened_string = sanitize_input(
-        shortened_string.html_safe, Array('img')
-    )
     newj['0']['tables'] = protocolsio_string_to_table_element(
       sanitize_input(unshortened_tables_string).html_safe
     )[0]
     table_str = protocolsio_string_to_table_element(
-      sanitize_input(shortened_string).html_safe
+      sanitize_input(shortened_string, Array('img')).html_safe
     )[1]
     newj['0']['description'] = table_str
     original_json['steps'].each_with_index do |step, pos_orig| # loop over steps

--- a/app/views/protocols/import_export/_import_json_protocol_p_desc.html.erb
+++ b/app/views/protocols/import_export/_import_json_protocol_p_desc.html.erb
@@ -88,8 +88,7 @@ $('#modal-import-json-protocol-preview').on('shown.bs.modal', function (e) {
     colHeaders: true,
     fillHandle: false,
     formulas: true,
-    readOnly: true,
-    height: 300
+    readOnly: true
   });
 }
 })

--- a/app/views/protocols/import_export/_import_json_protocol_p_desc.html.erb
+++ b/app/views/protocols/import_export/_import_json_protocol_p_desc.html.erb
@@ -88,7 +88,8 @@ $('#modal-import-json-protocol-preview').on('shown.bs.modal', function (e) {
     colHeaders: true,
     fillHandle: false,
     formulas: true,
-    readOnly: true
+    readOnly: true,
+    height: 300
   });
 }
 })

--- a/app/views/protocols/import_export/_import_json_protocol_s_desc.html.erb
+++ b/app/views/protocols/import_export/_import_json_protocol_s_desc.html.erb
@@ -153,8 +153,7 @@
       colHeaders: true,
       fillHandle: false,
       formulas: true,
-      readOnly: true,
-      height: 300
+      readOnly: true
     });
   }
   })

--- a/app/views/protocols/import_export/_import_json_protocol_s_desc.html.erb
+++ b/app/views/protocols/import_export/_import_json_protocol_s_desc.html.erb
@@ -122,7 +122,7 @@
         <% tables, garbage = protocolsio_string_to_table_element(step_info_string) %>
         <% if tables.present? %>
           <br><hr><br>
-          <% end %>
+        <% end %>
           <% table_count = 0 %>
           <% tables.each do |index, table| %>
           <%   table_hash = JSON.parse((Base64.decode64(table['contents']))) %>
@@ -130,7 +130,7 @@
           <%   step_table_elements_array.push([pio_table_id,table_hash['data']]) %>
           <div id="<%=pio_table_id%>" ></div>
           <%   table_count += 1 %>
-        <% end %>
+          <% end %>
         </div>
       </div>
     </div>
@@ -153,7 +153,8 @@
       colHeaders: true,
       fillHandle: false,
       formulas: true,
-      readOnly: true
+      readOnly: true,
+      height: 300
     });
   }
   })


### PR DESCRIPTION
Step description, step expected result, protocol description, protocol manuscript citation, protocol guidelines, protocol warning and protocol before start attributes all now dont get cut tables if they exceed the character limit and have a table included (the table now doesnt get cut, even though text will)