### PR TITLE
protocols io authors are now real authors, not user that added the protocol [SCI-1808]

### DIFF
--- a/app/views/protocols/import_export/_import_json_protocol_preview_modal.html.erb
+++ b/app/views/protocols/import_export/_import_json_protocol_preview_modal.html.erb
@@ -38,7 +38,7 @@
             <span class="glyphicon glyphicon-user">
             </span>&nbsp;<%= t('protocols.import_export.import_modal.authors_label') %>
           </label>
-          <%= f.text_field :authors, :value => pio_eval_title_len(sanitize_input(@json_object['full_name'])), class:
+          <%= f.text_field :authors, :value => pio_eval_title_len(sanitize_input(not_null(@json_object['authors']))), class:
           "form-control" %>
 
         </div>


### PR DESCRIPTION
The created at date from protocols io is in the description, but the "real" protocols.io created at date changes to the created at date of the time the protocol was imported into scinote. And yeah, authors are now authors of the protocol, not the user it was added by to protocols.io.