### PR TITLE
Allow setting of SMTP auth method through ENV variable

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -48,7 +48,7 @@ Rails.application.configure do
     address: Rails.application.secrets.mailer_address,
     port: Rails.application.secrets.mailer_port,
     domain: Rails.application.secrets.mailer_domain,
-    authentication: 'plain',
+    authentication: Rails.application.secrets.mailer_authentication,
     enable_starttls_auto: true,
     user_name: Rails.application.secrets.mailer_user_name,
     password: Rails.application.secrets.mailer_password

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,7 +33,7 @@ Rails.application.configure do
     address: Rails.application.secrets.mailer_address,
     port: Rails.application.secrets.mailer_port,
     domain: Rails.application.secrets.mailer_domain,
-    authentication: "plain",
+    authentication: Rails.application.secrets.mailer_authentication,
     enable_starttls_auto: true,
     user_name: Rails.application.secrets.mailer_user_name,
     password: Rails.application.secrets.mailer_password

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -62,7 +62,7 @@ Rails.application.configure do
     address: Rails.application.secrets.mailer_address,
     port: Rails.application.secrets.mailer_port,
     domain: Rails.application.secrets.mailer_domain,
-    authentication: "plain",
+    authentication: Rails.application.secrets.mailer_authentication,
     enable_starttls_auto: true,
     user_name: Rails.application.secrets.mailer_user_name,
     password: Rails.application.secrets.mailer_password

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -37,6 +37,7 @@ common: &common
   mailer_reply_to: <%= ENV["MAIL_REPLYTO"] %>
   mailer_address: <%= ENV["SMTP_ADDRESS"] %>
   mailer_port: <%= ENV["SMTP_PORT"] || "587" %>
+  mailer_authentication: <%= ENV["SMTP_AUTH_METHOD"] || "plain" %>
   mailer_domain: <%= ENV["SMTP_DOMAIN"] %>
   mailer_user_name: <%= ENV["SMTP_USERNAME"] %>
   mailer_password: <%= ENV["SMTP_PASSWORD"] %>


### PR DESCRIPTION
MS Exchange server requires 'login' auth method, but we use only 'plain' by default. This PR allows set it through config variable.