### PR TITLE
Table missing scrollbar [SCI-1818]

### DIFF
--- a/app/helpers/protocols_io_helper.rb
+++ b/app/helpers/protocols_io_helper.rb
@@ -52,7 +52,7 @@ module ProtocolsIoHelper
       tables[table_counter.to_s] = {}
       tr_number = table[0].scan(tr_regex).count
       diff = 5 - tr_number # always tables have atleast 5 rows
-      table_fix_str = tr_number > 4 ? table[0] : table[0] + empty_tbl_gen(diff)
+      table_fix_str = tr_number > 4 ? table[0] : table[0] + '<tr></tr>' * diff
       tr_strings = table_fix_str.scan(tr_regex)
       contents = {}
       contents['data'] = []
@@ -66,10 +66,7 @@ module ProtocolsIoHelper
           contents['data'][tr_counter].push(td_stripped)
         end
         next if td_counter >= 5
-        while diff > 0
-          contents['data'][tr_counter].push(' ')
-          diff -= 1
-        end
+        diff.times { contents['data'][tr_counter].push(' ') }
       end
       tables[table_counter.to_s]['contents'] = Base64.encode64(
         contents.to_s.sub('=>', ':')
@@ -77,15 +74,6 @@ module ProtocolsIoHelper
       tables[table_counter.to_s]['name'] = ' '
     end
     return tables, string_without_tables
-  end
-
-  def empty_tbl_gen(number)
-    result = ''
-    while number > 0
-      result += '<tr></tr>'
-      number -= 1
-    end
-    result
   end
 
   def string_html_table_remove(description_string)

--- a/app/helpers/protocols_io_helper.rb
+++ b/app/helpers/protocols_io_helper.rb
@@ -57,7 +57,12 @@ module ProtocolsIoHelper
       tables[table_counter.to_s] = {}
       tr_number = table[0].scan(tr_regex).count
       diff = PIO_TABLE_MIN_HEIGHT - tr_number # always tables have atleast 5 row
-      table_fix_str = tr_number > 4 ? table[0] : table[0] + '<tr></tr>' * diff
+      table_fix_str =
+        if tr_number >= PIO_TABLE_MIN_HEIGHT
+          table[0]
+        else
+          table[0] + '<tr></tr>' * diff
+        end
       tr_strings = table_fix_str.scan(tr_regex)
       contents = {}
       contents['data'] = []

--- a/app/helpers/protocols_io_helper.rb
+++ b/app/helpers/protocols_io_helper.rb
@@ -57,12 +57,8 @@ module ProtocolsIoHelper
       tables[table_counter.to_s] = {}
       tr_number = table[0].scan(tr_regex).count
       diff = PIO_TABLE_MIN_HEIGHT - tr_number # always tables have atleast 5 row
-      table_fix_str =
-        if tr_number >= PIO_TABLE_MIN_HEIGHT
-          table[0]
-        else
-          table[0] + '<tr></tr>' * diff
-        end
+      table_fix_str = table[0]
+      table_fix_str += '<tr></tr>' * diff if tr_number < PIO_TABLE_MIN_HEIGHT
       tr_strings = table_fix_str.scan(tr_regex)
       contents = {}
       contents['data'] = []
@@ -75,7 +71,7 @@ module ProtocolsIoHelper
           td_stripped = ActionController::Base.helpers.strip_tags(td[0])
           contents['data'][tr_counter].push(td_stripped)
         end
-        next if td_counter >= 5
+        next if td_counter >= PIO_TABLE_MIN_WIDTH
         diff.times { contents['data'][tr_counter].push(' ') }
       end
       tables[table_counter.to_s]['contents'] = Base64.encode64(

--- a/app/helpers/protocols_io_helper.rb
+++ b/app/helpers/protocols_io_helper.rb
@@ -39,6 +39,11 @@ module ProtocolsIoHelper
     I18n.t('protocols.protocols_io_import.too_long').length
   # The + 2 above (in title) is there because if the length was at the limit,
   # the cutter method had issues, this gives it some space
+
+  # below are default min table settings (minimum 5x5)
+  PIO_TABLE_MIN_WIDTH = 5
+  PIO_TABLE_MIN_HEIGHT = 5
+
   def protocolsio_string_to_table_element(description_string)
     string_without_tables = string_html_table_remove(description_string)
     table_regex = %r{<table\b[^>]*>(.*?)<\/table>}m
@@ -51,7 +56,7 @@ module ProtocolsIoHelper
     table_strings.each_with_index do |table, table_counter|
       tables[table_counter.to_s] = {}
       tr_number = table[0].scan(tr_regex).count
-      diff = 5 - tr_number # always tables have atleast 5 rows
+      diff = PIO_TABLE_MIN_HEIGHT - tr_number # always tables have atleast 5 row
       table_fix_str = tr_number > 4 ? table[0] : table[0] + '<tr></tr>' * diff
       tr_strings = table_fix_str.scan(tr_regex)
       contents = {}
@@ -60,7 +65,7 @@ module ProtocolsIoHelper
         td_strings = tr[0].scan(td_regex)
         contents['data'][tr_counter] = []
         td_counter = td_strings.count
-        diff = 5 - td_counter
+        diff = PIO_TABLE_MIN_WIDTH - td_counter
         td_strings.each do |td|
           td_stripped = ActionController::Base.helpers.strip_tags(td[0])
           contents['data'][tr_counter].push(td_stripped)


### PR DESCRIPTION
Tables are now always atleast 5x5 cells when they get imported ( like scinote standard new table), which also fixes the styling errors in protocol preview, the tables were having
