### PR TITLE
quick fix for if previous guid is unknown format [Protocols.io import]

### DIFF
--- a/app/helpers/protocols_io_helper.rb
+++ b/app/helpers/protocols_io_helper.rb
@@ -322,6 +322,7 @@ module ProtocolsIoHelper
 
   def protocols_io_guid_reorder_step_json(unordered_step_json)
     base_step = unordered_step_json.find { |step| step['previous_guid'].nil? }
+    return unordered_step_json if base_step.nil?
     number_of_steps = unordered_step_json.size
     step_order = []
     step_counter = 0


### PR DESCRIPTION
this doenst have a jira issue attached to it, since i just found this bug out yesterday, i was assuming first step always has previous_guid attribute to null, but this is not the case, as i found one protocol, that had it set to "00000000000000000000", a value that did not match any other guid.