### PR TITLE
Remove remotipart from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,7 +393,6 @@ GEM
     rdoc (4.3.0)
     recaptcha (4.6.3)
       json
-    remotipart (1.3.1)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -589,7 +588,6 @@ DEPENDENCIES
   rails_12factor
   rails_autolink (~> 1.1, >= 1.1.6)
   recaptcha
-  remotipart (~> 1.2)
   rgl
   roo (~> 2.7.1)
   rspec-rails


### PR DESCRIPTION
This was forgotten when fixing SCI-2270 (see #1069)