### PR TITLE
Fix Office Online (WOPI) editing of files [SCI-2266]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,7 +71,7 @@ gem 'jbuilder' # JSON structures via a Builder-style DSL
 gem 'activerecord-import'
 gem 'scenic', '~> 1.4'
 
-gem 'paperclip', '~> 5.1' # File attachment, image attachment library
+gem 'paperclip', '~> 5.3' # File attachment, image attachment library
 gem 'aws-sdk', '~> 2'
 
 gem 'delayed_job_active_record'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,8 +148,6 @@ GEM
       mail
     climate_control (0.2.0)
     cliver (0.3.2)
-    cocaine (0.5.8)
-      climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -227,7 +225,7 @@ GEM
       activesupport (>= 4.2.0)
     hammerjs-rails (2.0.8)
     hashie (3.5.7)
-    i18n (0.9.3)
+    i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     i18n-js (3.0.3)
       i18n (~> 0.6, >= 0.6.6)
@@ -320,12 +318,12 @@ GEM
       oauth2 (~> 1.1)
       omniauth (~> 1.2)
     orm_adapter (0.5.0)
-    paperclip (5.2.1)
+    paperclip (5.3.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
-      cocaine (~> 0.5.5)
       mime-types
       mimemagic (~> 0.3.0)
+      terrapin (~> 0.6.0)
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
@@ -485,6 +483,8 @@ GEM
       ruby-progressbar (~> 1.9)
       sourcemap (~> 0.1)
     stream (0.5)
+    terrapin (0.6.0)
+      climate_control (>= 0.0.3, < 1.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -492,7 +492,7 @@ GEM
       railties (>= 3.1.1)
     turbolinks (2.5.4)
       coffee-rails
-    tzinfo (1.2.4)
+    tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (4.1.4)
       execjs (>= 0.3.0, < 3)
@@ -575,7 +575,7 @@ DEPENDENCIES
   nokogiri (~> 1.8.1)
   omniauth
   omniauth-linkedin-oauth2
-  paperclip (~> 5.1)
+  paperclip (~> 5.3)
   pg (~> 0.18)
   phantomjs
   poltergeist

--- a/app/middlewares/wopi_method_override.rb
+++ b/app/middlewares/wopi_method_override.rb
@@ -1,0 +1,19 @@
+# When WOPI performs calls onto sciNote WOPI subdomain REST endpoints
+# Rack::MethodOverride MUST be omitted because it crashes the requests
+# due to trying to parse body of the requests
+class WopiMethodOverride
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    app = @app
+
+    unless WopiSubdomain.matches?(ActionDispatch::Request.new(env))
+      # Use the wrapped Rack::MethodOverride middleware
+      app = Rack::MethodOverride.new(@app)
+    end
+
+    app.call(env)
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,10 @@ module Scinote
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
+    # Swap the Rack::MethodOverride with a wrapped middleware for WOPI handling
+    require_relative '../app/middlewares/wopi_method_override'
+    config.middleware.swap Rack::MethodOverride, WopiMethodOverride
+
     # Load all model concerns, including subfolders
     config.autoload_paths += Dir["#{Rails.root}/app/models/concerns/**/*.rb"]
 


### PR DESCRIPTION
As usual, the solution was simple once you get to the root of it. In the process of updating Rails from `4.2.10` to `5.1.1`, `rack` was also upgraded from `1.6.8` to `2.0.3`. This newer version of `rack` handles parsing of body & query HTTP request parameters a bit differently (it was _refactored_).

The purpose of `Rack::MethodOverride` middleware (which is by default included in every Rails application) is to inspect the body of all HTTP requests, and check whether it includes `_method` data, which is a common "hack" (Rails also implement it this way) that browsers (actually, HTML forms - which only support `GET` and `POST` methods) use to support other HTTP methods (like `PUT`, `PATCH`, `DELETE`, ...).

The problem was that when WOPI server calls sciNote endpoints with [PutFile](http://wopi.readthedocs.io/projects/wopirest/en/latest/files/PutFile.html) - this is the RESTful endpoint that update the file contents on sciNote-side with changes that were made by user in Office Online - this `Rack::MethodOverride` middleware crashed when parsing the request body (which contains WOPI headers, and updated file contents), resulting in sciNote file becoming corrupted (with 0 bytes size).

Since the WOPI communication is server-to-server (and therefore allows for all the HTTP methods, including `PUT` etc.), `Rack::MethodOverride` is completely reduntant for WOPI calls, so I simply swap this middleware in Rack middlewares list with a "wrapper" middleware, that ignores `Rack::MethodOverride` for WOPI requests, and normally includes it for any other server request. We still need this middleware for other requests, because some forms in sciNote views use non-supported HTTP methods (like `PUT`).

Closes [SCI-2266](https://biosistemika.atlassian.net/browse/SCI-2266).