### PR TITLE
sign_out user after 7 days [fixes SCI-2323]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception, prepend: true
   before_action :authenticate_user!
-  before_action :check_max_session_time
   helper_method :current_team
   before_action :update_current_team, if: :user_signed_in?
   around_action :set_time_zone, if: :current_user
@@ -65,13 +64,6 @@ class ApplicationController < ActionController::Base
   end
 
   private
-
-  def check_max_session_time
-    if current_user && current_user.current_sign_in_at + 7.days < Time.now
-      sign_out current_user
-      redirect_to new_user_session_path
-    end
-  end
 
   def update_current_team
     if current_user.current_team_id.blank? &&

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception, prepend: true
   before_action :authenticate_user!
+  before_action :check_max_session_time
   helper_method :current_team
   before_action :update_current_team, if: :user_signed_in?
   around_action :set_time_zone, if: :current_user
@@ -64,6 +65,13 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def check_max_session_time
+    if current_user && current_user.current_sign_in_at + 7.days < Time.now
+      sign_out current_user
+      redirect_to new_user_session_path
+    end
+  end
 
   def update_current_team
     if current_user.current_team_id.blank? &&

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
   acts_as_token_authenticatable
   devise :invitable, :confirmable, :database_authenticatable, :registerable,
          :async, :recoverable, :rememberable, :trackable, :validatable,
-         :rememberable, :timeoutable, :omniauthable,
+         :timeoutable, :omniauthable,
          omniauth_providers: Extends::OMNIAUTH_PROVIDERS,
          stretches: Constants::PASSWORD_STRETCH_FACTOR
   has_attached_file :avatar,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,8 @@ class User < ApplicationRecord
   acts_as_token_authenticatable
   devise :invitable, :confirmable, :database_authenticatable, :registerable,
          :async, :recoverable, :rememberable, :trackable, :validatable,
-         :omniauthable, omniauth_providers: Extends::OMNIAUTH_PROVIDERS,
+         :rememberable, :timeoutable, :omniauthable,
+         omniauth_providers: Extends::OMNIAUTH_PROVIDERS,
          stretches: Constants::PASSWORD_STRETCH_FACTOR
   has_attached_file :avatar,
                     styles: {

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -176,7 +176,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :rememberable
   # The time the user will be remembered without asking for credentials again.
-  # config.remember_for = 2.weeks
+  config.remember_for = 1.weeks
 
   # Invalidates all the remember me tokens when the user signs out.
   config.expire_all_remember_me_on_sign_out = true
@@ -200,7 +200,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 3.hours
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     email 'admin_test@scinote.net'
     password 'asdf1243'
     password_confirmation 'asdf1243'
+    current_sign_in_at DateTime.now
   end
 end


### PR DESCRIPTION
https://biosistemika.atlassian.net/browse/SCI-2323

Here I used a custom before_action hook that checks the user last sign_in timestamp. We can't use Devise Timeoutable module here because it checks the idle time, not the last login time: http://www.rubydoc.info/github/plataformatec/devise/master/Devise/Models/Timeoutable