### PR TITLE
Remove unnecessary save on notifications

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -431,7 +431,6 @@ class User < ApplicationRecord
     define_method("#{name}=") do |value|
       attr_name = name.gsub('_notification', '').to_sym
       notifications_settings[attr_name] = value
-      save
     end
   end
 


### PR DESCRIPTION
These methods should behave as the rest of setters on `ActiveRecord`-s, ergo setting the model state, but not saving it.

The save is called at the end of the action inside the controller anyway, so this save is redundant.