### PR TITLE
adds asset_text_data to global search options

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -199,7 +199,8 @@ class Asset < ApplicationRecord
       Rails.logger.info "Asset #{id}: Creating extract text job"
       # The extract_asset_text also includes
       # estimated size calculation
-      delay(queue: :assets).extract_asset_text(team)
+      delay(queue: :assets, run_at: 20.minutes.from_now)
+        .extract_asset_text(team)
     else
       # Update asset's estimated size immediately
       update_estimated_size(team)
@@ -207,9 +208,7 @@ class Asset < ApplicationRecord
   end
 
   def extract_asset_text(team = nil)
-    if file.blank?
-      return
-    end
+    return if file.blank?
 
     begin
       file_path = file.path

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -177,6 +177,7 @@ class Constants
 
   TEXT_EXTRACT_FILE_TYPES = [
     'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.template',
     'application/pdf',
     'application/rtf',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -176,6 +176,7 @@ class Constants
   #=============================================================================
 
   TEXT_EXTRACT_FILE_TYPES = [
+    'application/msword',
     'application/pdf',
     'application/rtf',
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -53,12 +53,13 @@ class Extends
   # are only supported
   REPOSITORY_EXTRA_SEARCH_ATTR = ['repository_text_values.data',
                                   'repository_list_items.data',
-                                  'assets.file_file_name']
+                                  'assets.file_file_name',
+                                  'asset_text_data.data']
 
   # Array of includes used in search query for repository rows
   REPOSITORY_SEARCH_INCLUDES = [:repository_text_value,
                                 repository_list_value: :repository_list_item,
-                                repository_asset_value: :asset]
+                                repository_asset_value: { asset: :asset_text_datum }]
 
   # List of implemented core API versions
   API_VERSIONS = ['20170715']

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -53,13 +53,12 @@ class Extends
   # are only supported
   REPOSITORY_EXTRA_SEARCH_ATTR = ['repository_text_values.data',
                                   'repository_list_items.data',
-                                  'assets.file_file_name',
-                                  'asset_text_data.data']
+                                  'assets.file_file_name']
 
   # Array of includes used in search query for repository rows
   REPOSITORY_SEARCH_INCLUDES = [:repository_text_value,
                                 repository_list_value: :repository_list_item,
-                                repository_asset_value: { asset: :asset_text_datum }]
+                                repository_asset_value: :asset]
 
   # List of implemented core API versions
   API_VERSIONS = ['20170715']


### PR DESCRIPTION
https://biosistemika.atlassian.net/browse/SCI-2417

this feature works already the problem was in paperclip. When delayed_jobs executes too quickly the asset file was pointing to the spinner gif and cause malfunctions in text extraction. Hopefully, this will fix that issue.