### PR TITLE
Fix clean unconfirmed users task for LinkedIn

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -73,7 +73,7 @@ namespace :data do
     # Remove users who didn't finish signup with LinkedIn
     users = User.joins(:user_identities)
                 .where(confirmed_at: nil)
-                .where('created_at < ?', Devise.confirm_within.ago)
+                .where('users.created_at < ?', Devise.confirm_within.ago)
     destroy_users(users)
   end
 


### PR DESCRIPTION
The `rails data:clean_unconfirmed_users` (and, thus, also `rails data:clean`) was not working when cleaning LinkedIn users.