### PR TITLE
Fixes duplicate checkbox entries in activity log [SCI-1621]

### DIFF
--- a/app/assets/javascripts/protocols/steps.js.erb
+++ b/app/assets/javascripts/protocols/steps.js.erb
@@ -9,7 +9,7 @@
 
   // Sets callbacks for toggling checkboxes
   function applyCheckboxCallBack()  {
-    $("[data-action='check-item']").on('click', function(e){
+    $("[data-action='check-item']").off().on('click', function(e){
       var checkboxitem = $(this).find("input");
       var checked = checkboxitem.is(":checked");
       $.ajax({


### PR DESCRIPTION
The issue was that creating/updating/deleting steps and checkboxes caused the onclick jquery listeners to be reapplied ontop of the old ones, thus too many activities got logged, now it removes all listeners before applying new ones to the click .