### PR TITLE
Fixed disabled export button after new inventory item save [SCI-2629]

### DIFF
--- a/app/assets/javascripts/repositories/repository_datatable.js.erb
+++ b/app/assets/javascripts/repositories/repository_datatable.js.erb
@@ -907,7 +907,6 @@ var RepositoryDatatable = (function(global) {
       $('#addNewColumn').prop('disabled', true);
       $('#deleteRepositoryRecordsButton').addClass('disabled');
       $('#deleteRepositoryRecordsButton').prop('disabled', true);
-      $('#exportRepositoriesButton').addClass('disabled');
       $('#exportRepositoriesButton').off('click');
       $('#export-repositories').off('click');
       $('#assignRepositoryRecords').addClass('disabled');


### PR DESCRIPTION
The button seems to have been disabled by mistake, since the entire dropdown menu that contains this export button is disabled anyway, so there would be no way to access it.
line 899, file repository_datatable.js.erb

```
$('#repository-acitons-dropdown').addClass('disabled');

$('#repository-acitons-dropdown').prop('disabled', true);
```
