### PR TITLE
Fix bootstrap-select to work with turbolinks 5.x [SCI-2707]

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -262,4 +262,9 @@ var HelperModule = (function(){
       $('.modal').modal('hide');
     });
   });
+
+  /* Fix .selectpicker (bootstrap-select) to work with Turbolinks 5.x */
+  $(document).on('turbolinks:load', function() {
+    $(window).trigger('load.bs.select.data-api');
+  });
 })();

--- a/app/assets/javascripts/users/settings/teams/invite_users_modal.js
+++ b/app/assets/javascripts/users/settings/teams/invite_users_modal.js
@@ -173,8 +173,11 @@
     });
   }
 
-  $('[data-role=invite-users-modal]').each(function() {
-    initializeModal($(this));
+  $(document).on('turbolinks:load', function() {
+    $('[data-role=invite-users-modal]').each(function() {
+      initializeModal($(this));
+    });
+
+    initializeModalsToggle();
   });
-  initializeModalsToggle();
 }());


### PR DESCRIPTION
This was causing invite users modal, among other things, to not
function correctly after visiting another redirect within SciNote
using Turbolinks 5.x.

Closes [SCI-2707](https://biosistemika.atlassian.net/browse/SCI-2707).