### PR TITLE
Search page results from different teams than active not switching active team on click [SCI-2684]

### DIFF
--- a/app/controllers/users/settings_controller.rb
+++ b/app/controllers/users/settings_controller.rb
@@ -5,6 +5,10 @@ module Users
     ]
 
     def user_current_team
+      unless params[:user] && params[:user][:current_team_id]
+        redirect_to root_path
+        return
+      end
       team_id = params[:user][:current_team_id].to_i
       if @user.teams_ids.include?(team_id)
         @user.current_team_id = team_id

--- a/app/controllers/users/settings_controller.rb
+++ b/app/controllers/users/settings_controller.rb
@@ -12,6 +12,10 @@ module Users
         if @user.save
           flash[:success] = t('users.settings.changed_team_flash',
                               team: @changed_team.name)
+          if params[:user] && params[:user][:path]
+            redirect_to params[:user][:path]
+            return
+          end
           redirect_to root_path
           return
         end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -41,14 +41,13 @@ module SearchHelper
               method: :post,
               class: 'btn btn-success',
               data: {
-                no_turbolink: true,
                 confirm: t(
                   'users.settings.changed_team_in_search',
                   team: search_team.name
                 )
               }
     else
-      link_to text, path, class: 'btn btn-success', data: { no_turbolink: true }
+      link_to text, path, class: 'btn btn-success'
     end
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -7,13 +7,34 @@ module SearchHelper
     experiments.uniq
   end
 
+  def user_current_team_change(new_team_id)
+    team_id = new_team_id.to_i
+    if @user.teams_ids.include?(team_id)
+      @user.current_team_id = team_id
+      @changed_team = Team.find_by_id(@user.current_team_id)
+      if @user.save
+        flash[:success] = t('users.settings.changed_team_flash',
+                            team: @changed_team.name)
+        redirect_to root_path
+        return
+      end
+    end
+    flash[:alert] = t('users.settings.changed_team_error_flash')
+    redirect_back(fallback_location: root_path)
+  end
+
   def route_to_other_team(path, search_team, text)
     if search_team != current_team
+      user_current_team_change(search_team.id) unless path.include?('?team=')
       link_to text,
               path,
-              data: { no_turbolink: true,
-                      confirm: t('users.settings.changed_team_in_search',
-                                 team: search_team.name) }
+              data: {
+                no_turbolink: true,
+                confirm: t(
+                  'users.settings.changed_team_in_search',
+                  team: search_team.name
+                )
+              }
     else
       link_to text, path, data: { no_turbolink: true }
     end
@@ -21,13 +42,19 @@ module SearchHelper
 
   def route_to_other_team_btn(path, search_team, text)
     if search_team != current_team
+
       link_to text,
               path,
               class: 'btn btn-success',
-              data: { confirm: t('users.settings.changed_team_in_search',
-                                 team: search_team.name) }
+              data: {
+                no_turbolink: true,
+                confirm: t(
+                  'users.settings.changed_team_in_search',
+                  team: search_team.name
+                )
+              }
     else
-      link_to text, path, class: 'btn btn-success'
+      link_to text, path, class: 'btn btn-success', data: { no_turbolink: true }
     end
   end
 end

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -9,10 +9,14 @@ module SearchHelper
 
   def route_to_other_team(path, search_team, text)
     if search_team != current_team
-      #byebug
-      current_team_switch(search_team)
       link_to text,
-              path,
+              user_current_team_path(
+                user: {
+                  path: path,
+                  current_team_id: search_team.id
+                }
+              ),
+              method: :post,
               data: {
                 no_turbolink: true,
                 confirm: t(
@@ -28,7 +32,13 @@ module SearchHelper
   def route_to_other_team_btn(path, search_team, text)
     if search_team != current_team
       link_to text,
-              path,
+              user_current_team_path(
+                user: {
+                  path: path,
+                  current_team_id: search_team.id
+                }
+              ),
+              method: :post,
               class: 'btn btn-success',
               data: {
                 no_turbolink: true,

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -7,25 +7,10 @@ module SearchHelper
     experiments.uniq
   end
 
-  def user_current_team_change(new_team_id)
-    team_id = new_team_id.to_i
-    if @user.teams_ids.include?(team_id)
-      @user.current_team_id = team_id
-      @changed_team = Team.find_by_id(@user.current_team_id)
-      if @user.save
-        flash[:success] = t('users.settings.changed_team_flash',
-                            team: @changed_team.name)
-        redirect_to root_path
-        return
-      end
-    end
-    flash[:alert] = t('users.settings.changed_team_error_flash')
-    redirect_back(fallback_location: root_path)
-  end
-
   def route_to_other_team(path, search_team, text)
     if search_team != current_team
-      user_current_team_change(search_team.id) unless path.include?('?team=')
+      #byebug
+      current_team_switch(search_team)
       link_to text,
               path,
               data: {
@@ -42,7 +27,6 @@ module SearchHelper
 
   def route_to_other_team_btn(path, search_team, text)
     if search_team != current_team
-
       link_to text,
               path,
               class: 'btn btn-success',

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -42,7 +42,8 @@
                     <li class="team-name-item">
                       <a href="#"
                         data-id="<%= team.id %>"
-                        class="text-center change-team">
+                        class="text-center change-team"
+                        data-turbolinks="false">
                         <% if current_team == team %>
                           <span class="fas fa-check-circle"></span> <strong><%= team.name %></strong>
                         <% else %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -42,8 +42,7 @@
                     <li class="team-name-item">
                       <a href="#"
                         data-id="<%= team.id %>"
-                        class="text-center change-team"
-                        data-turbolinks="false">
+                        class="text-center change-team">
                         <% if current_team == team %>
                           <span class="fas fa-check-circle"></span> <strong><%= team.name %></strong>
                         <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,8 @@ Rails.application.routes.draw do
     post 'users/settings/user_current_team',
          to: 'users/settings#user_current_team',
          as: 'user_current_team'
+    get 'users/settings/user_current_team',
+        to: 'projects#index'
 
     get 'users/settings/teams',
         to: 'users/settings/teams#index',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,8 +65,11 @@ Rails.application.routes.draw do
     post 'users/settings/user_current_team',
          to: 'users/settings#user_current_team',
          as: 'user_current_team'
+    # Also changes users current team
+    # link_to sends get requests when opened in new tab for some reason
+    # So this route is simillar to the top one
     get 'users/settings/user_current_team',
-        to: 'projects#index'
+        to: 'users/settings#user_current_team'
 
     get 'users/settings/teams',
         to: 'users/settings/teams#index',


### PR DESCRIPTION
Its more of a hackish fix, but this is what i came up with, since opening the link_to in a new tab would for some reason cause a GET request, not a POST one, like i specified in the link_to constructor.