### PR TITLE
UPDATE Inventory item endpoint - unit tests [SCI-2697] (v2)

### DIFF
--- a/spec/requests/api/v1/inventory_items_controller_spec.rb
+++ b/spec/requests/api/v1/inventory_items_controller_spec.rb
@@ -245,4 +245,74 @@ RSpec.describe 'Api::V1::InventoryItemsController', type: :request do
       expect(hash_body).to match({})
     end
   end
+
+  describe 'PATCH inventory_items, #update' do
+    before :all do
+      @valid_headers['Content-Type'] = 'application/json'
+      @inventory_item = ActiveModelSerializers::SerializableResource.new(
+        RepositoryRow.last,
+        serializer: Api::V1::InventoryItemSerializer,
+        include: :inventory_cells
+      )
+    end
+
+    it 'Response with correctly updated inventory item for name field' do
+      hash_body = nil
+      updated_inventory_item = @inventory_item.as_json[:data]
+      updated_inventory_item[:attributes][:name] = Faker::Name.unique.name
+      patch api_v1_team_inventory_item_path(
+        id: RepositoryRow.last.id,
+        team_id: @teams.first.id,
+        inventory_id: @valid_inventory.id
+      ), params: { data: updated_inventory_item }.to_json,
+      headers: @valid_headers
+      expect(response).to have_http_status 200
+      expect { hash_body = json }.not_to raise_exception
+      expect(hash_body[:data].to_json).to match(updated_inventory_item.to_json)
+    end
+
+    it 'Response with correctly updated inventory item for list item column' do
+      hash_body = nil
+      updated_inventory_item = @inventory_item.as_json[:included]
+      updated_inventory_item.each do |cell|
+        attributes = cell[:attributes]
+        if attributes[:value_type] == 'list'
+          cell[:attributes] = {
+            value_type: 'list',
+            value: Faker::Name.unique.name,
+            column_id: 2
+          }
+        end
+      end
+      patch api_v1_team_inventory_item_path(
+        id: RepositoryRow.last.id,
+        team_id: @teams.first.id,
+        inventory_id: @valid_inventory.id
+      ), params: @inventory_item.to_json,
+      headers: @valid_headers
+      expect(response).to have_http_status 200
+      expect { hash_body = json }.not_to raise_exception
+      expect(hash_body[:included].to_json).to match(updated_inventory_item.to_json)
+    end
+
+    it 'Response with correctly updated inventory item for text item column' do
+      hash_body = nil
+      updated_inventory_item = @inventory_item.as_json[:included]
+      updated_inventory_item.each do |cell|
+        attributes = cell[:attributes]
+        if attributes[:value_type] == 'text'
+          attributes[:value] = Faker::Name.unique.name
+        end
+      end
+      patch api_v1_team_inventory_item_path(
+        id: RepositoryRow.last.id,
+        team_id: @teams.first.id,
+        inventory_id: @valid_inventory.id
+      ), params: @inventory_item.to_json,
+      headers: @valid_headers
+      expect(response).to have_http_status 200
+      expect { hash_body = json }.not_to raise_exception
+      expect(hash_body[:included].to_json).to match(updated_inventory_item.to_json)
+    end
+  end
 end


### PR DESCRIPTION
I'm reopening this because I accidentaly merged the original pull request.

This PR needs to be updated because the UPDATE Inventory item endpoint does not work as it should.

Closes [SCI-2697](https://biosistemika.atlassian.net/browse/SCI-2697).

This is the original revert commit message:
```
Revert "Revert "Merge branch 'mc-SC-2697' of https://github.com/czbiohub/scinote-web-1 into core-api""

This reverts commit 7ef85a9b60ff2453d4610387a117306ad17beecc.
```