### PR TITLE
Disabled turbolinks in left navigation bar protocols button [SCI-2760]

### DIFF
--- a/app/views/shared/_left_menu_bar.html.erb
+++ b/app/views/shared/_left_menu_bar.html.erb
@@ -14,7 +14,8 @@
         <% end %>
       </li>
       <li class="<%= "active" if templates_are_selected? %>">
-        <%= link_to protocols_path, id: "templates-link", title: t('left_menu_bar.templates') do %>
+        <%= link_to protocols_path, id: "templates-link", title: t('left_menu_bar.templates'),
+                                    data: { turbolinks: false } do %>
           <span class="fas fa-edit"></span>
           <span><%= t('left_menu_bar.templates') %></span>
         <% end %>


### PR DESCRIPTION
I tested it and it seemed to fix the issue of the protocol upload modal not displaying