### PR TITLE
Rename user_id to sub in JWT [SCI-2814]

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -75,17 +75,9 @@ module Api
         raise JWT::InvalidPayload, 'Default: Wrong ISS in the token'
       end
       payload = CoreJwt.decode(token)
-      @current_user = User.find_by_id(payload['user_id'])
+      @current_user = User.find_by_id(payload['sub'])
       unless current_user
         raise JWT::InvalidPayload, 'Default: User mapping not found'
-      end
-
-      # Implement sliding sessions, i.e send new token in case of successful
-      # authorization and when tokens TTL reached specific value (to avoid token
-      # generation on each request)
-      if CoreJwt.refresh_needed?(payload)
-        new_token = CoreJwt.encode(user_id: current_user.id)
-        response.headers['X-Access-Token'] = new_token
       end
     end
 

--- a/app/services/api/core_jwt.rb
+++ b/app/services/api/core_jwt.rb
@@ -25,16 +25,10 @@ module Api
       )[:iss].to_s
     end
 
-    def self.refresh_needed?(payload)
-      time_left = payload[:exp].to_i - Time.now.to_i
-      return true if time_left < (Api.configuration.core_api_token_ttl.to_i / 2)
-      false
-    end
-
     # Method used by Doorkeeper for custom tokens
     def self.generate(options = {})
       encode(
-        { user_id: options[:resource_owner_id] },
+        { sub: options[:resource_owner_id] },
         options[:expires_in].seconds.from_now.to_i
       )
     end

--- a/spec/support/api_helper.rb
+++ b/spec/support/api_helper.rb
@@ -1,14 +1,14 @@
 module ApiHelper
   def generate_token(user_id)
-    Api::CoreJwt.encode(user_id: user_id)
+    Api::CoreJwt.encode(sub: user_id)
   end
 
   def generate_expired_token(user_id)
-    Api::CoreJwt.encode({ user_id: user_id }, (Time.now.to_i - 300))
+    Api::CoreJwt.encode({ sub: user_id }, (Time.now.to_i - 300))
   end
 
   def decode_token(token)
-    Api::CoreJwt.decode(token)['user_id'].to_i
+    Api::CoreJwt.decode(token)['sub'].to_i
   end
 
   def json


### PR DESCRIPTION
https://biosistemika.atlassian.net/browse/SCI-2814

Encode current user id in 'sub' claim instead 'user_id' to be more in line with JWT standard.
Also remove old refresh token generation, not it will be handled by Doorkeeper.