### PR TITLE
Make AWS access key variables optional [SCI-2727]

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,10 +1,5 @@
-if ENV['AWS_ACCESS_KEY_ID']
-  Aws.config.update(
-    region: ENV['AWS_REGION'],
-    credentials: Aws::Credentials.new(
-      ENV['AWS_ACCESS_KEY_ID'], ENV['AWS_SECRET_ACCESS_KEY']
-    )
-  )
+# frozen_string_literal: true
 
+if ENV['PAPERCLIP_STORAGE'] == 's3'
   S3_BUCKET = Aws::S3::Resource.new.bucket(ENV['S3_BUCKET'])
 end

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -14,10 +14,8 @@ Paperclip::Attachment.default_options.merge!(
 Paperclip::UriAdapter.register
 
 if ENV['PAPERCLIP_STORAGE'] == 's3'
-  if ENV['S3_BUCKET'].nil? || ENV['AWS_REGION'].nil? ||
-     ENV['AWS_ACCESS_KEY_ID'].nil? || ENV['AWS_SECRET_ACCESS_KEY'].nil?
-    puts 'WARNING! Environment variables S3_BUCKET, AWS_REGION, '\
-         'AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set.'
+  if ENV['S3_BUCKET'].nil? || ENV['AWS_REGION'].nil?
+    puts 'WARNING! Environment variables S3_BUCKET and AWS_REGION must be set.'
     exit 1
   end
 


### PR DESCRIPTION
https://biosistemika.atlassian.net/browse/SCI-2727

By default AWS SDK loads credentials from ENV variables, but it also can load role from shared conf files when running on AWS.