### PR TITLE
Use built-in methods for Postgres extensions enabling [SCI-2864]

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -6,6 +6,8 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
   apt-get update -qq && \
   apt-get install -y \
   nodejs \
+  groff-base \
+  awscli \
   postgresql-client \
   netcat \
   default-jre-headless \

--- a/app/helpers/database_helper.rb
+++ b/app/helpers/database_helper.rb
@@ -4,20 +4,6 @@ module DatabaseHelper
     ActiveRecord::Base.connection.adapter_name == adapter_name
   end
 
-  # Create PostgreSQL extension. PostgreSQL only!
-  def create_extension(ext_name)
-    ActiveRecord::Base.connection.execute(
-      "CREATE EXTENSION #{ext_name};"
-    )
-  end
-
-  # Drop PostgreSQL extension. PostgreSQL only!
-  def drop_extension(ext_name)
-    ActiveRecord::Base.connection.execute(
-      "DROP EXTENSION #{ext_name};"
-    )
-  end
-
   # Create gist trigram index. PostgreSQL only!
   def add_gist_index(table, column)
     ActiveRecord::Base.connection.execute(

--- a/db/migrate/20151021082639_add_pg_trgm_support.rb
+++ b/db/migrate/20151021082639_add_pg_trgm_support.rb
@@ -4,13 +4,7 @@ include DatabaseHelper
 class AddPgTrgmSupport < ActiveRecord::Migration[4.2]
   def up
     if db_adapter_is? "PostgreSQL" then
-      create_extension :pg_trgm
-    end
-  end
-
-  def down
-    if db_adapter_is? "PostgreSQL" then
-      drop_extension :pg_trgm
+      enable_extension :pg_trgm
     end
   end
 end

--- a/db/migrate/20151103155048_add_btree_gist_extension.rb
+++ b/db/migrate/20151103155048_add_btree_gist_extension.rb
@@ -4,13 +4,7 @@ include DatabaseHelper
 class AddBtreeGistExtension < ActiveRecord::Migration[4.2]
   def up
     if db_adapter_is? "PostgreSQL" then
-      create_extension :btree_gist
-    end
-  end
-
-  def down
-    if db_adapter_is? "PostgreSQL" then
-      drop_extension :btree_gist
+      enable_extension :btree_gist
     end
   end
 end


### PR DESCRIPTION
[SCI-2864](https://biosistemika.atlassian.net/browse/SCI-2864)

Rails built-in methods for extension enabling use IF NOT EXISTS options, which allows us to skip it if extensions are already there

Also adds AWS cli to production image, might be used for backups