### PR TITLE
Change export all to use HTML instead of PDF [SCI-2902]

### DIFF
--- a/app/assets/stylesheets/reports_print.scss
+++ b/app/assets/stylesheets/reports_print.scss
@@ -160,4 +160,18 @@ div.print-report {
       }
     }
   }
+
+  .report-module-repository-element {
+    & > .report-element-header {
+      .repository-icon,.repository-name {
+        color: $color-black !important;
+      }
+    }
+
+    &:hover > .report-element-header {
+      .repository-icon,.repository-name {
+        color: $color-black !important;
+      }
+    }
+  }
 }

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -232,7 +232,7 @@ class Project < ApplicationRecord
     res
   end
 
-  def generate_report_pdf(user, team, pdf_name, obj_filenames = nil)
+  def generate_teams_export_report_html(user, team, html_name, obj_filenames = nil)
     ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
     proxy = Warden::Proxy.new({}, Warden::Manager.new({}))
     proxy.set_user(user, scope: :user, store: false)
@@ -246,10 +246,10 @@ class Project < ApplicationRecord
                                 obj_filenames: obj_filenames },
                       assigns: { project: self, report: report }
     parsed_page_html = Nokogiri::HTML(page_html_string)
-    parsed_pdf_html = parsed_page_html.at_css('#report-content')
+    parsed_html = parsed_page_html.at_css('#report-content')
 
-    tables = parsed_pdf_html.css('.hot-table-contents')
-                            .zip(parsed_pdf_html.css('.hot-table-container'))
+    tables = parsed_html.css('.hot-table-contents')
+                            .zip(parsed_html.css('.hot-table-container'))
     tables.each do |table_input, table_container|
       table_vals = JSON.parse(table_input['value'])
       table_data = table_vals['data']
@@ -285,15 +285,14 @@ class Project < ApplicationRecord
     end
 
     ApplicationController.render(
-      pdf: pdf_name,
-      header: { right: '[page] of [topage]' },
-      locals: { content: parsed_pdf_html.to_s },
-      template: 'reports/report.pdf.erb',
-      disable_javascript: true,
-      disable_internal_links: false,
+      layout: false,
+      locals: {
+        title: html_name,
+        content: parsed_html.children.map(&:to_s).join
+      },
+      template: 'team_zip_exports/report',
       current_user: user,
-      current_team: team,
-      extra: '--keep-relative-links'
+      current_team: team
     )
   ensure
     report.destroy if report.present?

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -232,7 +232,9 @@ class Project < ApplicationRecord
     res
   end
 
-  def generate_teams_export_report_html(user, team, html_name, obj_filenames = nil)
+  def generate_teams_export_report_html(
+    user, team, html_title, obj_filenames = nil
+  )
     ActionController::Renderer::RACK_KEY_TRANSLATION['warden'] ||= 'warden'
     proxy = Warden::Proxy.new({}, Warden::Manager.new({}))
     proxy.set_user(user, scope: :user, store: false)
@@ -249,7 +251,7 @@ class Project < ApplicationRecord
     parsed_html = parsed_page_html.at_css('#report-content')
 
     tables = parsed_html.css('.hot-table-contents')
-                            .zip(parsed_html.css('.hot-table-container'))
+                        .zip(parsed_html.css('.hot-table-container'))
     tables.each do |table_input, table_container|
       table_vals = JSON.parse(table_input['value'])
       table_data = table_vals['data']
@@ -287,7 +289,7 @@ class Project < ApplicationRecord
     ApplicationController.render(
       layout: false,
       locals: {
-        title: html_name,
+        title: html_title,
         content: parsed_html.children.map(&:to_s).join
       },
       template: 'team_zip_exports/report',

--- a/app/models/team_zip_export.rb
+++ b/app/models/team_zip_export.rb
@@ -115,11 +115,11 @@ class TeamZipExport < ZipExport
         end
       end
 
-      # Generate and export whole project report PDF
-      pdf_name = "#{project_name} Report.pdf"
+      # Generate and export whole project report HTML
+      html_name = "#{project_name} Report.html"
       project_report_pdf =
-        p.generate_report_pdf(@user, @team, pdf_name, obj_filenames)
-      file = FileUtils.touch("#{project_path}/#{pdf_name}").first
+        p.generate_teams_export_report_html(@user, @team, html_name, obj_filenames)
+      file = FileUtils.touch("#{project_path}/#{html_name}").first
       File.open(file, 'wb') { |f| f.write(project_report_pdf) }
     end
 

--- a/app/models/team_zip_export.rb
+++ b/app/models/team_zip_export.rb
@@ -117,8 +117,9 @@ class TeamZipExport < ZipExport
 
       # Generate and export whole project report HTML
       html_name = "#{project_name} Report.html"
-      project_report_pdf =
-        p.generate_teams_export_report_html(@user, @team, html_name, obj_filenames)
+      project_report_pdf = p.generate_teams_export_report_html(
+        @user, @team, html_name, obj_filenames
+      )
       file = FileUtils.touch("#{project_path}/#{html_name}").first
       File.open(file, 'wb') { |f| f.write(project_report_pdf) }
     end

--- a/app/views/reports/elements/_new_element.html.erb
+++ b/app/views/reports/elements/_new_element.html.erb
@@ -1,6 +1,6 @@
 <% if !defined? hide then hide = false end %>
 <% if !defined? initial then initial = false end %>
-<div class="new-element <%= "hidden" if hide %> <%= "initial" if initial %>" data-ts="ignore" data-type="new" title="<%=t "projects.reports.elements.new_element.title" %>"
+<div class="new-element <%= "hidden" if hide %> <%= "initial" if initial %>" data-ts="ignore" data-type="new" title="<%=t "projects.reports.elements.new_element.title" %>">
   <a href="" class="new-element-href" data-action="add-new-elements">
     <div class="line left-line">
       <div class="filler-wrapper">

--- a/app/views/team_zip_exports/report.html.erb
+++ b/app/views/team_zip_exports/report.html.erb
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <meta charset="utf-8">
+    <style type="text/css">
+      <%= Rails.application.assets['application.css'].to_s.html_safe %>
+    </style>
+    <title><%= title %></title>
+  </head>
+  <body class='print-report-body'>
+    <div class='print-report'>
+    <%= content.html_safe %>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
Within scope of [SCI-2902](https://biosistemika.atlassian.net/browse/SCI-2902), we've agreed that we can use HTML within export all, instead of PDF, to avoid {{wkhtml2pdf}} memory leaks & issues that can occur in production environments in background worker.

The only potential issue with this PR - that needs to be tested in production - is whether the line `<%= Rails.application.assets['application.css'].to_s.html_safe %>` within `report.html.erb` will work on production environments.