### PR TITLE
Fix assets include in export all report to work on production env [SCI-2902]

### DIFF
--- a/app/views/team_zip_exports/report.html.erb
+++ b/app/views/team_zip_exports/report.html.erb
@@ -2,7 +2,7 @@
   <head>
     <meta charset="utf-8">
     <style type="text/css">
-      <%= Rails.application.assets['application.css'].to_s.html_safe %>
+      <%= Rails.application.assets_manifest.find_sources('application.css').first.to_s.html_safe %>
     </style>
     <title><%= title %></title>
   </head>


### PR DESCRIPTION
The problematic line was only working in development environment, and not in production environment (due to pre-compilation of assets).

Closes [SCI-2902](https://biosistemika.atlassian.net/browse/SCI-2902).