### PR TITLE
Add force_encoding to export all report view template [SCI-2902]

### DIFF
--- a/app/views/team_zip_exports/report.html.erb
+++ b/app/views/team_zip_exports/report.html.erb
@@ -2,13 +2,19 @@
   <head>
     <meta charset="utf-8">
     <style type="text/css">
-      <%= Rails.application.assets_manifest.find_sources('application.css').first.to_s.html_safe %>
+      <%= Rails.application
+               .assets_manifest
+               .find_sources('application.css')
+               .first
+               .to_s
+               .force_encoding(Encoding::UTF_8)
+               .html_safe %>
     </style>
     <title><%= title %></title>
   </head>
   <body class='print-report-body'>
     <div class='print-report'>
-    <%= content.html_safe %>
+      <%= content.force_encoding(Encoding::UTF_8).html_safe %>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Fix a production-environment-only bug where the export all reports could not be generated due to the following error:
```
incompatible character encodings: ASCII-8BIT and UTF-8
/usr/src/app/app/models/zip_export.rb:85:in `eval'
/usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/core_ext/string/output_safety.rb:188:in `concat'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/buffers.rb:12:in `<<'
/usr/src/app/app/views/team_zip_exports/report.html.erb:11:in `_app_views_team_zip_exports_report_html_erb___3246725560120153748_47298614331980'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/template.rb:157:in `block in render'
/usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/notifications.rb:166:in `block in instrument'
/usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/template.rb:352:in `instrument_render_template'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/template.rb:155:in `render'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/renderer/template_renderer.rb:52:in `block (2 levels) in render_template'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/renderer/abstract_renderer.rb:42:in `block in instrument'
/usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/notifications.rb:166:in `block in instrument'
/usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
/usr/local/bundle/gems/activesupport-5.1.6/lib/active_support/notifications.rb:166:in `instrument'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/renderer/abstract_renderer.rb:41:in `instrument'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/renderer/template_renderer.rb:51:in `block in render_template'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/renderer/template_renderer.rb:59:in `render_with_layout'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/renderer/template_renderer.rb:50:in `render_template'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/renderer/template_renderer.rb:14:in `render'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/renderer/renderer.rb:42:in `render_template'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/renderer/renderer.rb:23:in `render'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/rendering.rb:103:in `_render_template'
/usr/local/bundle/gems/actionpack-5.1.6/lib/action_controller/metal/streaming.rb:217:in `_render_template'
/usr/local/bundle/gems/actionview-5.1.6/lib/action_view/rendering.rb:83:in `render_to_body'
/usr/local/bundle/gems/actionpack-5.1.6/lib/action_controller/metal/rendering.rb:52:in `render_to_body'
/usr/local/bundle/gems/actionpack-5.1.6/lib/action_controller/metal/renderers.rb:141:in `render_to_body'
/usr/local/bundle/gems/actionpack-5.1.6/lib/abstract_controller/rendering.rb:46:in `render_to_string'
/usr/local/bundle/gems/actionpack-5.1.6/lib/action_controller/metal/rendering.rb:41:in `render_to_string'
/usr/local/bundle/gems/wicked_pdf-1.1.0/lib/wicked_pdf/pdf_helper.rb:53:in `render_to_string_with_wicked_pdf'
/usr/local/bundle/gems/wicked_pdf-1.1.0/lib/wicked_pdf/pdf_helper.rb:31:in `render_to_string'
/usr/local/bundle/gems/actionpack-5.1.6/lib/action_controller/renderer.rb:81:in `render'
/usr/local/bundle/gems/actionpack-5.1.6/lib/action_controller/metal/rendering.rb:11:in `render'
/usr/src/app/app/models/project.rb:285:in `generate_teams_export_report_html'
/usr/src/app/app/models/team_zip_export.rb:121:in `block in generate_teams_zip'
/usr/src/app/app/models/team_zip_export.rb:52:in `each'
/usr/src/app/app/models/team_zip_export.rb:52:in `generate_teams_zip'
(eval):1:in `fill_content'
/usr/src/app/app/models/zip_export.rb:85:in `eval'
/usr/src/app/app/models/zip_export.rb:85:in `fill_content'
/usr/src/app/app/models/team_zip_export.rb:30:in `generate_exportable_zip'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/performable_method.rb:26:in `perform'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/backend/base.rb:81:in `block in invoke_job'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:61:in `block in initialize'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:66:in `execute'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/backend/base.rb:78:in `invoke_job'
/usr/local/bundle/gems/newrelic_rpm-4.7.1.340/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb:129:in `block in invoke_job'
/usr/local/bundle/gems/newrelic_rpm-4.7.1.340/lib/new_relic/agent/instrumentation/controller_instrumentation.rb:369:in `perform_action_with_newrelic_trace'
/usr/local/bundle/gems/newrelic_rpm-4.7.1.340/lib/new_relic/agent/instrumentation/delayed_job_instrumentation.rb:128:in `invoke_job'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:230:in `block (2 levels) in run'
/usr/local/lib/ruby/2.4.0/timeout.rb:93:in `block in timeout'
/usr/local/lib/ruby/2.4.0/timeout.rb:103:in `timeout'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:230:in `block in run'
/usr/local/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:229:in `run'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:312:in `block in reserve_and_run_one_job'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:61:in `block in initialize'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:66:in `execute'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:312:in `reserve_and_run_one_job'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:213:in `block in work_off'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:212:in `times'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:212:in `work_off'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:175:in `block (4 levels) in start'
/usr/local/lib/ruby/2.4.0/benchmark.rb:308:in `realtime'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:174:in `block (3 levels) in start'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:61:in `block in initialize'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:66:in `execute'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:173:in `block (2 levels) in start'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:172:in `loop'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:172:in `block in start'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/plugins/clear_locks.rb:7:in `block (2 levels) in <class:ClearLocks>'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:79:in `block (2 levels) in add'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:61:in `block in initialize'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:79:in `block in add'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:66:in `execute'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/lifecycle.rb:40:in `run_callbacks'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/worker.rb:171:in `start'
/usr/local/bundle/gems/delayed_job-4.1.4/lib/delayed/tasks.rb:9:in `block (2 levels) in <top (required)>'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/task.rb:271:in `block in execute'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/task.rb:271:in `each'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/task.rb:271:in `execute'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/task.rb:213:in `block in invoke_with_call_chain'
/usr/local/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/task.rb:193:in `invoke_with_call_chain'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/task.rb:182:in `invoke'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/application.rb:160:in `invoke_task'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/application.rb:116:in `block (2 levels) in top_level'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/application.rb:116:in `each'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/application.rb:116:in `block in top_level'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/application.rb:125:in `run_with_threads'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/application.rb:110:in `top_level'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/application.rb:83:in `block in run'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/application.rb:186:in `standard_exception_handling'
/usr/local/bundle/gems/rake-12.3.1/lib/rake/application.rb:80:in `run'
/usr/local/bundle/gems/rake-12.3.1/exe/rake:27:in `<top (required)>'
/usr/local/bundle/bin/rake:23:in `load'
/usr/local/bundle/bin/rake:23:in `<main>'
```

Closes [SCI-2902](https://biosistemika.atlassian.net/browse/SCI-2902).