### PR TITLE
Update Ruby to 2.4.5 and add jemalloc package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM ruby:2.4.4
+FROM ruby:2.4.5
 MAINTAINER BioSistemika <info@biosistemika.com>
 
 # additional dependecies
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
   apt-get update -qq && \
   apt-get install -y \
+  libjemalloc1 \
   nodejs \
   postgresql-client \
   default-jre-headless \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,10 +1,11 @@
-FROM ruby:2.4.4
+FROM ruby:2.4.5
 MAINTAINER BioSistemika <info@biosistemika.com>
 
 # additional dependecies
 RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
   apt-get update -qq && \
   apt-get install -y \
+  libjemalloc1 \
   nodejs \
   groff-base \
   awscli \

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'http://rubygems.org'
 
-ruby '2.4.4'
+ruby '2.4.5'
 
 gem 'rails', '5.1.6'
 gem 'webpacker', '~> 2.0'


### PR DESCRIPTION
Updates Ruby version and adds optional implementation of memory allocator(jemalloc, can be enabled through env variables, can reduce total memory usage)