### PR TITLE
Fix the Cucumber tests so they pass

### DIFF
--- a/features/settings_page/team.feature
+++ b/features/settings_page/team.feature
@@ -24,18 +24,11 @@ Feature: Team settings
     And I should see "BioSistemika Process Company" on "#team-name" element
 
   @javascript
-  Scenario: Successfully adds team description
-    Given I'm on "BioSistemika Process" team settings page
-    Then I click on ".description-label" element
-    And I fill in "I was on Triglav one summer." in "team_description" textarea field
-    Then I click "Save" button
-    And I should see "I was on Triglav one summer." on ".description-label" element
-
-  @javascript
   Scenario: Successfully changes team description
     Given I'm on "BioSistemika Process" team settings page
     Then I click on ".description-label" element
-    And I change "Lorem ipsum dolor sit amet, consectetuer adipiscing eli." with "I was on Triglav one summer." in "team_description" textarea field
+    Then I should not see "I was on Triglav one summer." on ".description-label" element
+    And I fill in "I was on Triglav one summer." in "team_description" textarea field
     Then I click "Save" button
     And I should see "I was on Triglav one summer." on ".description-label" element
 

--- a/features/step_definitions/shared_steps.rb
+++ b/features/step_definitions/shared_steps.rb
@@ -128,6 +128,11 @@ Then(/^I change "([^"]*)" with "([^"]*)" in "([^"]*)" textarea field$/) do |old_
   textarea.set(new_text)
 end
 
+Then(/^I should not see "([^"]*)" on "([^"]*)" element$/) do |text, element|
+  wait_for_ajax
+  expect(find(element)).not_to have_content(text)
+end
+
 Then(/^I should see "([^"]*)" on "([^"]*)" element$/) do |text, element|
   wait_for_ajax
   expect(find(element)).to have_content(text)


### PR DESCRIPTION
With the change of factories, single Cucumber test stopped
working due to text in the test being dependant on a now randomly
(Faker) defined value.