### PR TITLE
Add recaptcha to invitation modal [SCI-2935]

### DIFF
--- a/app/assets/stylesheets/themes/scinote.scss
+++ b/app/assets/stylesheets/themes/scinote.scss
@@ -1405,6 +1405,10 @@ table.dataTable {
       margin: 0;
     }
   }
+
+  .g-recaptcha {
+    margin-top: 20px;
+  }
 }
 
 // Image preview modal

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -229,8 +229,7 @@ class TeamsController < ApplicationController
 
   def export_projects
     unless export_proj_requests_exceeded?
-      current_user.export_vars['num_of_export_all_last_24_hours'] += 1
-      current_user.save
+      current_user.increase_daily_exports_counter!
 
       generate_export_projects_zip
 

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -5,6 +5,8 @@ module Users
 
     prepend_before_action :check_captcha, only: [:update]
 
+    prepend_before_action :check_captcha_for_invite, only: [:invite_users]
+
     before_action :check_invite_users_permission, only: :invite_users
 
     before_action :update_sanitized_params, only: :update
@@ -185,6 +187,15 @@ module Users
 
       if target_user.assignments_notification
         UserNotification.create(notification: notification, user: target_user)
+      end
+    end
+
+    def check_captcha_for_invite
+      if Rails.configuration.x.enable_recaptcha
+        unless verify_recaptcha
+          render json: { recaptcha_error: t('invite_users.errors.recaptcha') },
+                 status: :unprocessable_entity
+        end
       end
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,8 @@ class User < ApplicationRecord
 
   default_variables(
     export_vars: {
-      num_of_export_all_last_24_hours: 0
+      num_of_export_all_last_24_hours: 0,
+      last_export_timestamp: Date.today.to_time.to_i
     }
   )
 
@@ -503,6 +504,16 @@ class User < ApplicationRecord
       attr_name = name.gsub('_notification', '').to_sym
       notifications_settings[attr_name] = value
     end
+  end
+
+  def increase_daily_exports_counter!
+    if Time.at(export_vars['last_export_timestamp'] || 0).to_date == Date.today
+      export_vars['num_of_export_all_last_24_hours'] += 1
+    else
+      export_vars['last_export_timestamp'] = Date.today.to_time.to_i
+      export_vars['num_of_export_all_last_24_hours'] = 1
+    end
+    save
   end
 
   protected

--- a/app/views/shared/_invite_users_modal.html.erb
+++ b/app/views/shared/_invite_users_modal.html.erb
@@ -99,6 +99,16 @@ invite_to_team = type.in?(%w(invite_to_team invite_to_team_with_role))
               </div>
             <% end %>
           <% end %>
+          <% if ENV['ENABLE_RECAPTCHA'] %>
+            <div id="recaptcha-service" class="g-recaptcha"
+                 data-callback="recaptchaCallback"
+                 data-sitekey=<%= ENV['RECAPTCHA_SITE_KEY'] %>></div>
+            <script type="text/javascript" src="https://www.google.com/recaptcha/api.js?hl=en"></script>
+            <input type="hidden" id="recaptcha-invite-modal" value="">
+            <div class="form-group has-error hidden" id="recaptcha-error-msg" >
+              <span class="has-error help-block"></span>
+            </div>
+          <% end %>
         </div>
         <div class="results-container" data-role="step-results" data-clear="true">
         </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1831,6 +1831,8 @@ en:
     invite_guest: "As Guests"
     invite_user: "As Normal Users"
     invite_admin: "As Administrators"
+    errors:
+      recaptcha: "reCAPTCHA verification failed, please try again"
     results:
       heading: "Invitation results:"
       user_exists: "User is already a member of SciNote."

--- a/lib/tasks/exportable_items.rake
+++ b/lib/tasks/exportable_items.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :exportable_items do
   desc 'Removes exportable zip files'
   task cleanup: :environment do
@@ -5,24 +7,5 @@ namespace :exportable_items do
     ZipExport.where('created_at < ?', num.days.ago).destroy_all
     puts "All exportable zip files older than " \
          "'#{num.days.ago}' have been removed"
-  end
-
-  desc 'Resets export project counter to 0'
-  task reset_export_projects_counter: :environment do
-    User.find_each do |user|
-      User.transaction do
-        begin
-          user.export_vars['num_of_export_all_last_24_hours'] = 0
-          user.save
-        rescue ActiveRecord::ActiveRecordError,
-               ArgumentError,
-               ActiveRecord::RecordNotSaved => e
-          puts "Error resetting users num_of_export_all_last_24_hours " \
-               "variable to 0, transaction reverted: #{e}"
-        end
-      end
-    end
-    puts 'Export project counter successfully ' \
-         'reset on all users'
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -198,4 +198,62 @@ describe User, type: :model do
       expect(activities).to include activity_two
     end
   end
+
+  describe '#increase_daily_exports_counter!' do
+    let(:user) { create :user }
+    context 'when last_export_timestamp is set' do
+      it 'increases counter by 1' do
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['num_of_export_all_last_24_hours']
+          }.from(0).to(1)
+      end
+
+      it 'sets last_export_timestamp on today' do
+        user.export_vars['last_export_timestamp'] = Date.yesterday.to_time.to_i
+        user.save
+
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['last_export_timestamp']
+          }.to(Date.today.to_time.to_i)
+      end
+
+      it 'sets new counter for today' do
+        user.export_vars = {
+          'num_of_export_all_last_24_hours': 3,
+          'last_export_timestamp': Date.yesterday.to_time.to_i
+        }
+        user.save
+
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['num_of_export_all_last_24_hours']
+          }.from(3).to(1)
+      end
+    end
+
+    context 'when last_export_timestamp not exists (existing users)' do
+      it 'sets last_export_timestamp on today' do
+        user.export_vars.delete('last_export_timestamp')
+        user.save
+
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['last_export_timestamp']
+          }.from(nil).to(Date.today.to_time.to_i)
+      end
+
+      it 'starts count reports with 1' do
+        user.export_vars.delete('last_export_timestamp')
+        user.export_vars['num_of_export_all_last_24_hours'] = 2
+        user.save
+
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['num_of_export_all_last_24_hours']
+          }.from(2).to(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Jira ticket: [SCI-2935](https://biosistemika.atlassian.net/browse/SCI-2935?filter=-1)

**todo:**
Add ReCaptcha to invitation modal 

**What's done:** 
Added `before_filter`, updated `ajax` call `invite_users`

**NOTE**
I didn't use existing implementation with `recaptcha_tag` helper because I am not inside of `form` element. 
Now we have included `recaptcha` at 3 diffrent users experiences, everyone has own `before_filter` for checking captcha. If we will use `recaptcha` on more places, implementing universal `check_captcha` on higher controller level should be a better way and keep other logic after validation outside of that `before_filter`. 


