### PR TITLE
Refactor num_of_export_all_last_24_hours increasing/reseting logic [SCI-2968]

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -229,8 +229,7 @@ class TeamsController < ApplicationController
 
   def export_projects
     unless export_proj_requests_exceeded?
-      current_user.export_vars['num_of_export_all_last_24_hours'] += 1
-      current_user.save
+      current_user.increase_daily_exports_counter!
 
       generate_export_projects_zip
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,7 +56,8 @@ class User < ApplicationRecord
 
   default_variables(
     export_vars: {
-      num_of_export_all_last_24_hours: 0
+      num_of_export_all_last_24_hours: 0,
+      last_export_timestamp: Date.today.to_time.to_i
     }
   )
 
@@ -503,6 +504,16 @@ class User < ApplicationRecord
       attr_name = name.gsub('_notification', '').to_sym
       notifications_settings[attr_name] = value
     end
+  end
+
+  def increase_daily_exports_counter!
+    if Time.at(export_vars['last_export_timestamp'] || 0).to_date == Date.today
+      export_vars['num_of_export_all_last_24_hours'] += 1
+    else
+      export_vars['last_export_timestamp'] = Date.today.to_time.to_i
+      export_vars['num_of_export_all_last_24_hours'] = 1
+    end
+    save
   end
 
   protected

--- a/lib/tasks/exportable_items.rake
+++ b/lib/tasks/exportable_items.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :exportable_items do
   desc 'Removes exportable zip files'
   task cleanup: :environment do
@@ -5,24 +7,5 @@ namespace :exportable_items do
     ZipExport.where('created_at < ?', num.days.ago).destroy_all
     puts "All exportable zip files older than " \
          "'#{num.days.ago}' have been removed"
-  end
-
-  desc 'Resets export project counter to 0'
-  task reset_export_projects_counter: :environment do
-    User.find_each do |user|
-      User.transaction do
-        begin
-          user.export_vars['num_of_export_all_last_24_hours'] = 0
-          user.save
-        rescue ActiveRecord::ActiveRecordError,
-               ArgumentError,
-               ActiveRecord::RecordNotSaved => e
-          puts "Error resetting users num_of_export_all_last_24_hours " \
-               "variable to 0, transaction reverted: #{e}"
-        end
-      end
-    end
-    puts 'Export project counter successfully ' \
-         'reset on all users'
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -198,4 +198,62 @@ describe User, type: :model do
       expect(activities).to include activity_two
     end
   end
+
+  describe '#increase_daily_exports_counter!' do
+    let(:user) { create :user }
+    context 'when last_export_timestamp is set' do
+      it 'increases counter by 1' do
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['num_of_export_all_last_24_hours']
+          }.from(0).to(1)
+      end
+
+      it 'sets last_export_timestamp on today' do
+        user.export_vars['last_export_timestamp'] = Date.yesterday.to_time.to_i
+        user.save
+
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['last_export_timestamp']
+          }.to(Date.today.to_time.to_i)
+      end
+
+      it 'sets new counter for today' do
+        user.export_vars = {
+          'num_of_export_all_last_24_hours': 3,
+          'last_export_timestamp': Date.yesterday.to_time.to_i
+        }
+        user.save
+
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['num_of_export_all_last_24_hours']
+          }.from(3).to(1)
+      end
+    end
+
+    context 'when last_export_timestamp not exists (existing users)' do
+      it 'sets last_export_timestamp on today' do
+        user.export_vars.delete('last_export_timestamp')
+        user.save
+
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['last_export_timestamp']
+          }.from(nil).to(Date.today.to_time.to_i)
+      end
+
+      it 'starts count reports with 1' do
+        user.export_vars.delete('last_export_timestamp')
+        user.export_vars['num_of_export_all_last_24_hours'] = 2
+        user.save
+
+        expect { user.increase_daily_exports_counter! }
+          .to change {
+            user.reload.export_vars['num_of_export_all_last_24_hours']
+          }.from(2).to(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Jira ticket: [SCI-2968](https://biosistemika.atlassian.net/browse/SCI-2968?filter=-1)

**ToDo:**
Get rid of this Rake task (and cron job) by storing the timestamp of the last "day" within this JSONB variables field

**What's done:** 
- Removed rake task
- Added method for `User` for resetting and increasing counter `num_of_export_all_last_24_hours`