### PR TITLE
System Notifications - Migration of existing data

### DIFF
--- a/lib/tasks/notifications.rake
+++ b/lib/tasks/notifications.rake
@@ -17,7 +17,8 @@ namespace :notifications do
         modal_title: system_notification.title,
         modal_body: system_notification.message,
         show_on_login: false,
-        source_created_at: system_notification.created_at
+        source_created_at: system_notification.created_at,
+        last_time_changed_at: system_notification.created_at
       )
 
       created_at = system_notification.created_at

--- a/lib/tasks/notifications.rake
+++ b/lib/tasks/notifications.rake
@@ -1,23 +1,72 @@
-namespace :notifications do
-  desc 'Creates new system notification for all active users'
-  task :new_system, [:title, :message] => :environment do |_, args|
-    include NotificationsHelper
+# frozen_string_literal: true
 
-    if args.blank? ||
-       args.empty? ||
-       args[:title].blank? ||
-       args[:message].blank?
-      puts 'One or both of arguments are missing'
-      return
+namespace :notifications do
+  desc 'Copies system notifications to newly created data structure. IT SHOULD BE RUN ONE TIME ONLY'
+  task copy_system_notifications: :environment do
+    t0 = Time.now
+    system_notifications = Notification
+                           .where(type_of: :system_message)
+                           .where(generator_user_id: nil)
+                           .where.not('title like ?', 'Congratulations%')
+
+    system_notifications.each do |system_notification|
+      new_notification = SystemNotification.create!(
+        source_id: -1,
+        title: system_notification.title,
+        description: system_notification.message,
+        modal_title: system_notification.title,
+        modal_body: system_notification.message,
+        show_on_login: false,
+        source_created_at: system_notification.created_at
+      )
+
+      created_at = system_notification.created_at
+
+      sql = ' INSERT INTO user_system_notifications
+          (
+            user_id,
+            created_at,
+            updated_at,
+            system_notification_id,
+            seen_at,
+            read_at
+          )
+          VALUES
+        '
+      user_notifications = UserNotification
+                           .where(notification_id: system_notification.id)
+      values_array = user_notifications.map do |user_notification|
+        user_notification
+          .slice(:user_id, :created_at, :updated_at)
+          .merge(system_notification_id: new_notification.id)
+          .merge(seen_at: created_at, read_at: created_at)
+          .values
+          .map { |v| "'#{v}'" }
+          .join(',')
+      end
+
+      values_sql = values_array
+                   .map { |v| "(#{v})" }
+                   .join(',')
+
+      sql += values_sql
+      ActiveRecord::Base.connection.execute(sql)
     end
 
-    title = args[:title]
-    message = args[:message]
+    t1 = Time.now
+    puts "Task took #{t1 - t0}"
+  end
 
-    puts 'Creating following system notification:'
-    puts "    ***  #{title} ***"
-    puts "    #{I18n.l(Time.now, format: :full)} | #{message}"
+  desc 'Removes obsolete system notifications from notifications table.'
+  task delete_obsolete_system_notifications: :environment do
+    system_notifications = Notification
+                           .where(type_of: :system_message)
+                           .where(generator_user_id: nil)
+                           .where.not('title like ?', 'Congratulations%')
+    UserNotification
+      .where(notification_id: system_notifications.pluck(:id))
+      .delete_all
 
-    create_system_notification(title, message)
+    system_notifications.delete_all
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-2953](https://biosistemika.atlassian.net/browse/SCI-2953)

### What was done
Added "copy" and "delete" rake task. Removed obsolete "new_system" task. 

### Note:
This code is a bit ugly. We have to transform and copy approx 620K of user_notification record. In order to make this script faster I'm building raw SQL string and then executing it. However, this is a one-trick-pony, so I believe it's acceptable. Maybe we should delete these tasks after they are ran. 

**Note 2:** This pull request also includes @urbanrotnik commits.
