### PR TITLE
[SCI-3006] After changing order of inventory columns item can not be edited, deleted, copied

### DIFF
--- a/app/assets/javascripts/repositories/repository_datatable.js.erb
+++ b/app/assets/javascripts/repositories/repository_datatable.js.erb
@@ -1284,6 +1284,7 @@ var RepositoryDatatable = (function(global) {
         });
         reorderer.order(listIds, false);
         loadColumnsNames();
+        initRowSelection();
       }
     });
     $('.sorting').on('click', checkAvailableColumns);


### PR DESCRIPTION
Jira ticket: https://biosistemika.atlassian.net/browse/SCI-2957

### What was done
Problem was, that after changing column order, row-selector losing change event. So i add row selection init function after each reorder action.

