### PR TITLE
Add flag for archived tasks to experiment exporter [SCI-3033]

### DIFF
--- a/app/models/experiment.rb
+++ b/app/models/experiment.rb
@@ -100,12 +100,6 @@ class Experiment < ApplicationRecord
     end
   end
 
-  def active_module_groups
-    my_module_groups.joins(:my_modules)
-                    .where('my_modules.archived = ?', false)
-                    .distinct
-  end
-
   def active_modules
     my_modules.where(archived: false)
   end

--- a/app/models/my_module_group.rb
+++ b/app/models/my_module_group.rb
@@ -10,7 +10,7 @@ class MyModuleGroup < ApplicationRecord
              optional: true
   has_many :my_modules, inverse_of: :my_module_group, dependent: :nullify
 
-  scope :active, (lambda do
+  scope :without_archived_modules, (lambda do
     joins(:my_modules).where('my_modules.archived = ?', false).distinct
   end)
 

--- a/app/models/my_module_group.rb
+++ b/app/models/my_module_group.rb
@@ -10,6 +10,10 @@ class MyModuleGroup < ApplicationRecord
              optional: true
   has_many :my_modules, inverse_of: :my_module_group, dependent: :nullify
 
+  scope :active, (lambda do
+    joins(:my_modules).where('my_modules.archived = ?', false).distinct
+  end)
+
   def deep_clone_to_experiment(current_user, experiment)
     clone = MyModuleGroup.new(
       created_by: created_by,

--- a/app/services/model_exporters/experiment_exporter.rb
+++ b/app/services/model_exporters/experiment_exporter.rb
@@ -41,8 +41,8 @@ module ModelExporters
         my_modules = @experiment.my_modules
         my_module_groups = @experiment.my_module_groups
       else
-        my_modules = @experiment.active_my_modules
-        my_module_groups = @experiment.active_module_groups
+        my_modules = @experiment.my_modules.active
+        my_module_groups = @experiment.my_module_groups.active
       end
       return {
         experiment: @experiment,

--- a/app/services/model_exporters/experiment_exporter.rb
+++ b/app/services/model_exporters/experiment_exporter.rb
@@ -42,7 +42,7 @@ module ModelExporters
         my_module_groups = @experiment.my_module_groups
       else
         my_modules = @experiment.my_modules.active
-        my_module_groups = @experiment.my_module_groups.active
+        my_module_groups = @experiment.my_module_groups.without_archived_modules
       end
       return {
         experiment: @experiment,

--- a/spec/services/templates_service_spec.rb
+++ b/spec/services/templates_service_spec.rb
@@ -37,9 +37,9 @@ describe TemplatesService do
         expect(tmpl_exp.name).to eq(demo_exp.name)
         expect(tmpl_exp.uuid).to_not eq(nil)
         expect(tmpl_exp.my_modules.pluck(:name))
-          .to match_array(demo_exp.my_modules.pluck(:name))
+          .to match_array(demo_exp.active_my_modules.pluck(:name))
         tmpl_tasks = tmpl_exp.my_modules
-        demo_tasks = demo_exp.my_modules
+        demo_tasks = demo_exp.active_my_modules
         demo_tasks.each do |demo_task|
           tmpl_task = tmpl_tasks.find_by_name(demo_task.name)
           expect(tmpl_task.name).to eq(demo_task.name)


### PR DESCRIPTION
Jira ticket: [SCI-3033](https://biosistemika.atlassian.net/browse/SCI-3033)

### What was done
_Flag for archived tasks was added to disable exporting of archived tasks when exporting the templates. When exporting the team, archived tasks should be added to export._
