### PR TITLE
System Notification Emails [SCI-2961]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,7 +59,7 @@ gem 'delayed_paperclip',
     git: 'https://github.com/jrgifford/delayed_paperclip.git',
     ref: 'fcf574c'
 gem 'faker' # Generate fake data
-gem 'httparty'
+gem 'httparty', '~> 0.13.1'
 gem 'i18n-js', '~> 3.0' # Localization in javascript files
 gem 'jbuilder' # JSON structures via a Builder-style DSL
 gem 'logging', '~> 2.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,7 +247,8 @@ GEM
     hammerjs-rails (2.0.8)
     hashdiff (0.3.8)
     hashie (3.5.7)
-    httparty (0.16.2)
+    httparty (0.13.7)
+      json (~> 1.8)
       multi_xml (>= 0.5.2)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -600,7 +601,7 @@ DEPENDENCIES
   faker
   figaro
   hammerjs-rails
-  httparty
+  httparty (~> 0.13.1)
   i18n-js (~> 3.0)
   jbuilder
   jquery-rails

--- a/app/mailers/app_mailer.rb
+++ b/app/mailers/app_mailer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AppMailer < Devise::Mailer
   helper :application, :mailer, :input_sanitize
   include Devise::Controllers::UrlHelpers
@@ -18,6 +20,19 @@ class AppMailer < Devise::Mailer
       to: @user.email,
       subject: subject
     }.merge(opts)
+    mail(headers)
+  end
+
+  def system_notification(user, system_notification)
+    @user = user
+    @system_notification = system_notification
+
+    headers = {
+      to: @user.email,
+      subject: "[#{t('system_notifications.emails.title')}] "\
+               "#{@system_notification.title}"
+    }
+
     mail(headers)
   end
 end

--- a/app/mailers/app_mailer.rb
+++ b/app/mailers/app_mailer.rb
@@ -23,15 +23,14 @@ class AppMailer < Devise::Mailer
     mail(headers)
   end
 
-  def system_notification(user, system_notification)
+  def system_notification(user, system_notification, opts = {})
     @user = user
     @system_notification = system_notification
 
     headers = {
       to: @user.email,
-      subject: "[#{t('system_notifications.emails.title')}] "\
-               "#{@system_notification.title}"
-    }
+      subject: t('system_notifications.emails.subject')
+    }.merge(opts)
 
     mail(headers)
   end

--- a/app/models/user_system_notification.rb
+++ b/app/models/user_system_notification.rb
@@ -6,8 +6,15 @@ class UserSystemNotification < ApplicationRecord
 
   scope :unseen, -> { where(seen_at: nil) }
 
-  def self.mark_as_seen(notifications_id)
-    where(system_notification_id: notifications_id)
+  def send_email
+    if user.system_message_email_notification
+      AppMailer
+        .system_notification(user, system_notification)
+    end
+  end
+
+  def self.mark_as_seen(notifications)
+    where(system_notification_id: notifications)
       .update_all(seen_at: Time.now)
   end
 

--- a/app/services/notifications/sync_system_notifications_service.rb
+++ b/app/services/notifications/sync_system_notifications_service.rb
@@ -81,6 +81,7 @@ module Notifications
             .where(source_id: attrs[:source_id]).first_or_initialize(attrs)
 
         if n.new_record?
+          n.users = User.all
           n.save!
         elsif n.last_time_changed_at < attrs[:last_time_changed_at]
           n.update_attributes!(attrs)

--- a/app/views/users/mailer/system_notification.html.erb
+++ b/app/views/users/mailer/system_notification.html.erb
@@ -1,0 +1,10 @@
+<p>
+  <%= I18n.t("system_notifications.emails.intro_paragraph", user_name: @user.name) %>
+</p>
+<p>
+  <%= link_to @system_notification.title.html_safe, system_notifications_url %>
+</p>
+
+<p>
+  <%= @system_notification.description.html_safe %>
+</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,6 +57,8 @@ Rails.application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
+  config.action_mailer.preview_path = "#{Rails.root}/test/mailers/previews"
+
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: Rails.application.secrets.mail_server_url }
   config.action_mailer.default_options = { from: Rails.application.secrets.mail_from }
   config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :smtp
+  # config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {
     address: Rails.application.secrets.mailer_address,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1292,6 +1292,9 @@ en:
     create:
       success_flash: "Successfully added sample group <strong>%{sample_group}</strong> to team <strong>%{team}</strong>."
   system_notifications:
+    emails:
+      title: "What's new notification"
+      intro_paragraph: "Hello %{user_name}, you received new What's new notification!"
     index:
       whats_new: "What's New"
       more_notifications: "More system notifications"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1293,7 +1293,7 @@ en:
       success_flash: "Successfully added sample group <strong>%{sample_group}</strong> to team <strong>%{team}</strong>."
   system_notifications:
     emails:
-      title: "What's new notification"
+      subject: "You've received a What's new notification"
       intro_paragraph: "Hello %{user_name}, you received new What's new notification!"
     index:
       whats_new: "What's New"

--- a/spec/models/user_system_notification_spec.rb
+++ b/spec/models/user_system_notification_spec.rb
@@ -15,6 +15,25 @@ describe UserSystemNotification do
     it { is_expected.to belong_to(:system_notification) }
   end
 
+  describe '.send_email' do
+    context 'when user has enabled notifications' do
+      it 'delivers new email' do
+        allow(user_system_notification.user)
+          .to receive(:system_message_email_notification).and_return(true)
+
+        expect { user_system_notification.send_email&.deliver_now }
+          .to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
+
+    context 'when user has disabled notifications' do
+      it 'doesn\'t deliver new email' do
+        expect { user_system_notification.send_email&.deliver_now }
+          .not_to(change { ActionMailer::Base.deliveries.count })
+      end
+    end
+  end
+
   describe 'Methods' do
     let(:notifcation_one) { create :system_notification }
     let(:notifcation_two) { create :system_notification }

--- a/spec/models/user_system_notification_spec.rb
+++ b/spec/models/user_system_notification_spec.rb
@@ -16,19 +16,30 @@ describe UserSystemNotification do
   end
 
   describe '.send_email' do
+    before do
+      Delayed::Worker.delay_jobs = false
+    end
+
+    after do
+      Delayed::Worker.delay_jobs = true
+    end
+
     context 'when user has enabled notifications' do
-      it 'delivers new email' do
+      it 'delivers an email on creating new user_system_notification' do
         allow(user_system_notification.user)
           .to receive(:system_message_email_notification).and_return(true)
 
-        expect { user_system_notification.send_email&.deliver_now }
+        expect { user_system_notification.save }
           .to change { ActionMailer::Base.deliveries.count }.by(1)
       end
     end
 
     context 'when user has disabled notifications' do
-      it 'doesn\'t deliver new email' do
-        expect { user_system_notification.send_email&.deliver_now }
+      it 'doesn\'t deliver email on creating new user_system_notification' do
+        allow(user_system_notification.user)
+          .to receive(:system_message_email_notification).and_return(false)
+
+        expect { user_system_notification.save }
           .not_to(change { ActionMailer::Base.deliveries.count })
       end
     end

--- a/spec/models/user_system_notification_spec.rb
+++ b/spec/models/user_system_notification_spec.rb
@@ -15,7 +15,7 @@ describe UserSystemNotification do
     it { is_expected.to belong_to(:system_notification) }
   end
 
-  describe '.send_email' do
+  describe '.create' do
     before do
       Delayed::Worker.delay_jobs = false
     end
@@ -25,22 +25,22 @@ describe UserSystemNotification do
     end
 
     context 'when user has enabled notifications' do
-      it 'delivers an email on creating new user_system_notification' do
+      it 'calls send an email on creation' do
         allow(user_system_notification.user)
           .to receive(:system_message_email_notification).and_return(true)
 
-        expect { user_system_notification.save }
-          .to change { ActionMailer::Base.deliveries.count }.by(1)
+        expect(user_system_notification).to receive(:send_email)
+        user_system_notification.save
       end
     end
 
     context 'when user has disabled notifications' do
-      it 'doesn\'t deliver email on creating new user_system_notification' do
+      it 'doesn\'t call send an email on createion' do
         allow(user_system_notification.user)
           .to receive(:system_message_email_notification).and_return(false)
 
-        expect { user_system_notification.save }
-          .not_to(change { ActionMailer::Base.deliveries.count })
+        expect(user_system_notification).not_to receive(:send_email)
+        user_system_notification.save
       end
     end
   end

--- a/spec/services/notifications/sync_system_notifications_service_spec.rb
+++ b/spec/services/notifications/sync_system_notifications_service_spec.rb
@@ -17,6 +17,14 @@ describe Notifications::SyncSystemNotificationsService do
     { notifications: notifications }
   end
 
+  before(:all) do
+    Timecop.freeze
+  end
+
+  after(:all) do
+    Timecop.return
+  end
+
   context 'when request is successful' do
     before do |test|
       if test.metadata[:add_notifications_before]
@@ -65,6 +73,12 @@ describe Notifications::SyncSystemNotificationsService do
       allow(SystemNotification).to receive(:last_sync_timestamp).and_return(nil)
 
       expect(service_call.errors).to have_key(:last_sync_timestamp)
+    end
+
+    it 'adds 20 user_system_notifications records' do
+      create :user # add another user, so have 2 users in DB
+
+      expect { service_call }.to change { UserSystemNotification.count }.by(20)
     end
   end
 

--- a/test/mailers/previews/app_mailer_preview.rb
+++ b/test/mailers/previews/app_mailer_preview.rb
@@ -82,6 +82,12 @@ class AppMailerPreview < ActionMailer::Preview
     )
   end
 
+  def system_notification
+    sn = FactoryBot.build(:system_notification)
+    user = FactoryBot.build(:user)
+    AppMailer.system_notification(user, sn)
+  end
+
   private
 
   def fake_user


### PR DESCRIPTION
Jira ticket: [SCI-2961](https://biosistemika.atlassian.net/browse/SCI-2961)

### What was done
- Method for send email when a new notification added
- Add `user_system_notification` record to "assign" notification to user
- Covered with tests

#### ToDo:
- ~~Styling emails?~~  -> GitLab PR

### Note:
@Ducz0r
- I found out during working on those emails that I forgot in `SyncService` add many_many record for User and Notification.  This is fixed here in the second commit. 
- Billing addon and styled emails? Is this part of this scope? 
I think I cover other requirements... 

### UPDATE: 
I figured out custom templates systems in billing addon. Reviewer review both PRs, please :)   
[GitLab PR](https://gitlab.com/biosistemika/scinote/addons/billing/merge_requests/69/)

- Add custom tempalte in billing add-on
- Downgrade version for `HTTParty`. We have a dependency in billing_addon over gem `quaderno/quaderno-ruby` to an older version. So I have set the same version in core. I didn't see better way
- Add fixes for passing tests
- Lock some "time sensitive" tests by `Timecop.freeze`