### PR TITLE
Add action_name to sidebar cache as dependency [SCI-2930]

### DIFF
--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -11,7 +11,7 @@
        data-current-task="<%= current_task&.id %>">
     <div class="tree">
       <ul>
-        <% cache [current_user, current_team] do %>
+        <% cache [action_name, current_user, current_team] do %>
           <%= render partial: 'shared/sidebar/projects' %>
         <% end %>
       </ul>

--- a/app/views/shared/sidebar/_experiments.html.erb
+++ b/app/views/shared/sidebar/_experiments.html.erb
@@ -1,7 +1,7 @@
 <% if project.active_experiments.present? %>
   <ul>
     <% project.active_experiments.each do |experiment| %>
-      <% cache [current_user, experiment] do %>
+      <% cache [action_name, current_user, experiment] do %>
         <li data-parent="candidate" data-experiment-id="<%= experiment.id %>">
           <span class="tree-link line-wrap first-indent">
             <i class="no-arrow"></i>

--- a/app/views/shared/sidebar/_projects.html.erb
+++ b/app/views/shared/sidebar/_projects.html.erb
@@ -1,6 +1,6 @@
 <ul>
   <% @projects_tree.each do |project| %>
-    <% cache [current_user, project] do %>
+    <% cache [action_name, current_user, project] do %>
       <li data-parent="candidate" data-project-id="<%= project.id %>">
         <span class="tree-link line-wrap no-indent">
           <i class="no-arrow"></i>


### PR DESCRIPTION
Jira ticket: [SCI-2930](https://biosistemika.atlassian.net/browse/SCI-2930)

### What was done
Caching was currently using only the `current_user` and the current element (project, experiment, task). `action_name` is being used in `sidebar_helper` and if we don't depend on the `action_name` variable while caching, the old one will be used throughout all actions, making hyperlinks while clicking on element outdated.

### Note:
You should enable caching in `config/environments/development.rb` for this error to occur.
