### PR TITLE
Due date is not red for today anymore [SCI-3069]

### DIFF
--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -248,14 +248,14 @@ class MyModule < ApplicationRecord
   end
 
   def is_overdue?(datetime = DateTime.current)
-    due_date.present? and datetime.utc > due_date.utc
+    due_date.present? and datetime.utc > due_date_shifted
   end
 
   def overdue_for_days(datetime = DateTime.current)
-    if due_date.blank? or due_date.utc > datetime.utc
-      return 0
+    if due_date.blank? || due_date_shifted > datetime.utc
+      0
     else
-      return ((datetime.utc.to_i - due_date.utc.to_i) / (60*60*24).to_f).ceil
+      ((datetime.utc.to_i - due_date_shifted.to_i) / 1.day.to_f).ceil
     end
   end
 
@@ -264,7 +264,14 @@ class MyModule < ApplicationRecord
   end
 
   def is_due_in?(datetime, diff)
-    due_date.present? and datetime.utc < due_date.utc and datetime.utc > (due_date.utc - diff)
+    due_date.present? &&
+      datetime.utc < due_date_shifted &&
+      datetime.utc > (due_date_shifted - diff)
+  end
+
+  def due_date_shifted
+    # Selected due date should still be included
+    due_date.utc + 1.day
   end
 
   def space_taken

--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -248,14 +248,14 @@ class MyModule < ApplicationRecord
   end
 
   def is_overdue?(datetime = DateTime.current)
-    due_date.present? and datetime.utc > due_date_shifted
+    due_date.present? && datetime.utc > due_date.end_of_day
   end
 
   def overdue_for_days(datetime = DateTime.current)
-    if due_date.blank? || due_date_shifted > datetime.utc
+    if due_date.blank? || due_date.end_of_day > datetime.utc
       0
     else
-      ((datetime.utc.to_i - due_date_shifted.to_i) / 1.day.to_f).ceil
+      ((datetime.utc.to_i - due_date.end_of_day.to_i) / 1.day.to_f).ceil
     end
   end
 
@@ -265,13 +265,8 @@ class MyModule < ApplicationRecord
 
   def is_due_in?(datetime, diff)
     due_date.present? &&
-      datetime.utc < due_date_shifted &&
-      datetime.utc > (due_date_shifted - diff)
-  end
-
-  def due_date_shifted
-    # Selected due date should still be included
-    due_date.utc + 1.day
+      datetime.utc < due_date.end_of_day &&
+      datetime.utc > (due_date.end_of_day - diff)
   end
 
   def space_taken

--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -248,14 +248,14 @@ class MyModule < ApplicationRecord
   end
 
   def is_overdue?(datetime = DateTime.current)
-    due_date.present? && datetime.utc > due_date.end_of_day
+    due_date.present? && datetime.utc > due_date.end_of_day.utc
   end
 
   def overdue_for_days(datetime = DateTime.current)
-    if due_date.blank? || due_date.end_of_day > datetime.utc
+    if due_date.blank? || due_date.end_of_day.utc > datetime.utc
       0
     else
-      ((datetime.utc.to_i - due_date.end_of_day.to_i) / 1.day.to_f).ceil
+      ((datetime.utc.to_i - due_date.end_of_day.utc.to_i) / 1.day.to_f).ceil
     end
   end
 
@@ -265,8 +265,8 @@ class MyModule < ApplicationRecord
 
   def is_due_in?(datetime, diff)
     due_date.present? &&
-      datetime.utc < due_date.end_of_day &&
-      datetime.utc > (due_date.end_of_day - diff)
+      datetime.utc < due_date.end_of_day.utc &&
+      datetime.utc > (due_date.end_of_day.utc - diff)
   end
 
   def space_taken


### PR DESCRIPTION
Jira ticket:
[SCI-3069](https://biosistemika.atlassian.net/browse/SCI-3069)

### What was done
Change due_date to be shifted 1 day forward

#### ToDo:
Maybe better solution would be to change time to 23:59:59 on due_date
update, but would require migration. I can do it this way as well, since
I don't like this solution.