### PR TITLE
update_all_templates task now executes jobs in background [SCI-3109]

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -146,7 +146,7 @@ namespace :data do
         TemplatesService.new.delay(
           run_at: i.hours.from_now,
           queue: :templates,
-          priority: 1
+          priority: 5
         ).update_team(team)
       end
     end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -131,12 +131,25 @@ namespace :data do
   end
 
   desc 'Update all templates projects'
-  task update_all_templates: :environment do
+  task :update_all_templates,
+       %i(slice_size) => [:environment] do |_, args|
+    args.with_defaults(slice_size: 800)
+
     Rails.logger.info('Templates, syncing all templates projects')
-    updated, total = TemplatesService.new.update_all_templates
-    Rails.logger.info(
-      "Templates, total number of updated projects: #{updated} out of #{total}}"
-    )
+    Team.all.order(updated_at: :desc)
+        .each_slice(args[:slice_size].to_i).with_index do |teams, i|
+      Rails.logger.info("Processing slice with index #{i}. " \
+                        "First team: #{teams.first.id}, " \
+                        "Last team: #{teams.last.id}.")
+
+      teams.each do |team|
+        TemplatesService.new.delay(
+          run_at: i.hours.from_now,
+          queue: :templates,
+          priority: 1
+        ).update_team(team)
+      end
+    end
   end
 
   desc 'Create demo project on existing users'


### PR DESCRIPTION
Jira ticket: [SCI-3109](https://biosistemika.atlassian.net/browse/SCI-3109)

### What was done
update_all_templates through rake task is not delayed. I avoided changing `update_all_templates` in `TemplateService` because it's being used by rufus scheduler and I don't what happens if such thing is delayed. Additionally there would be no statistic how many were updated.

