### PR TITLE
Global activities creating service [SCI-3103]

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -103,17 +103,13 @@ class ProjectsController < ApplicationController
       )
       up.save
 
-      # Create "project created" activity
-      Activity.create(
-        type_of: :create_project,
-        owner: current_user,
-        project: @project,
-        message: t(
-          "activities.create_project",
-          user: current_user.full_name,
-          project: @project.name
-        )
-      )
+      Activities::CreateActivityService
+        .call(activity_type: :create_project,
+              owner: current_user,
+              subject: @project,
+              team: @project.team,
+              project: @project,
+              message_items: { project: @project.id })
 
       message = t('projects.create.success_flash', name: @project.name)
       respond_to do |format|

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Activity < ApplicationRecord
+  include ActivityValuesModel
+
   enum type_of: Extends::ACTIVITY_TYPES
 
   belongs_to :owner, inverse_of: :activities, class_name: 'User'
@@ -19,6 +21,12 @@ class Activity < ApplicationRecord
   validates :subject_type, inclusion: { in: Extends::ACTIVITY_SUBJECT_TYPES,
                                         allow_blank: true }
 
+  store_accessor :values, :message_items
+
+  default_values(
+    message_items: {}
+  )
+
   def self.activity_types_list
     type_ofs.map  do |key, value|
       {
@@ -30,14 +38,6 @@ class Activity < ApplicationRecord
 
   def old_activity?
     subject.nil?
-  end
-
-  def message_items
-    values['message_items'].with_indifferent_access.merge(user: owner.id)
-  end
-
-  def html_message
-    I18n.t "activities.#{type_of}", message_items
   end
 
   private

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -32,6 +32,14 @@ class Activity < ApplicationRecord
     subject.nil?
   end
 
+  def message_items
+    values['message_items'].with_indifferent_access.merge(user: owner.id)
+  end
+
+  def html_message
+    I18n.t "activities.#{type_of}", message_items
+  end
+
   private
 
   def activity_version

--- a/app/models/concerns/activity_values_model.rb
+++ b/app/models/concerns/activity_values_model.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ActivityValuesModel
+  extend ActiveSupport::Concern
+
+  # rubocop:disable Style/ClassVars
+  @@default_values = HashWithIndifferentAccess.new
+  # rubocop:enable Style/ClassVars
+
+  included do
+    serialize :values, JsonbHashSerializer
+    after_initialize :init_default_values, if: :new_record?
+    before_create :add_user
+  end
+
+  class_methods do
+    def default_values(dfs)
+      @@default_values.merge!(dfs)
+    end
+  end
+
+  protected
+
+  def init_default_values
+    self.values = @@default_values
+  end
+
+  def add_user
+    message_items.merge!(user: { id: owner.id, value: owner.full_name })
+  end
+end

--- a/app/models/concerns/activity_values_model.rb
+++ b/app/models/concerns/activity_values_model.rb
@@ -26,6 +26,9 @@ module ActivityValuesModel
   end
 
   def add_user
-    message_items.merge!(user: { id: owner.id, value: owner.full_name })
+    message_items.merge!(user: { id: owner.id,
+                                 value: owner.full_name,
+                                 type: 'User',
+                                 value_for: 'full_name' })
   end
 end

--- a/app/services/activities/create_activity_service.rb
+++ b/app/services/activities/create_activity_service.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Activities
+  class CreateActivityService
+    extend Service
+
+    attr_reader :errors, :activity
+
+    def initialize(activity_type:,
+                   owner:,
+                   team:,
+                   project:,
+                   subject:,
+                   message_items: {})
+      @activity = Activity.new
+      @activity.type_of = activity_type
+      @activity.owner = owner
+      @activity.team = team
+      @activity.subject = subject
+      @activity.project = project if project
+      @activity.values = { message_items: message_items }
+
+      @errors = {}
+    end
+
+    def call
+      generate_breadcrumbs
+      @activity.save
+
+      self
+    end
+
+    def succeed?
+      @errors.none?
+    end
+
+    private
+
+    def generate_breadcrumbs
+      @activity.values[:breadcrumbs] = [
+        { team: { id: @activity.team.id, value: @activity.team.name } },
+        { project: { id: @activity.project.id, value: @activity.project.name } }
+      ]
+    end
+  end
+end

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -86,11 +86,15 @@ class Extends
 
   ACTIVITY_SUBJECT_TYPES = %w(
     Team Repository Project Experiment MyModule Result Protocol Step
-  )
+  ).freeze
 
   SEARCHABLE_ACTIVITY_SUBJECT_TYPES = %w(
     Repository Project Experiment MyModule Result Protocol Step
-  )
+  ).freeze
+
+  ACTIVITY_MESSAGE_ITEMS_TYPES =
+    ACTIVITY_SUBJECT_TYPES + %w(User Tag RepositoryRow RepositoryColumn)
+    .freeze
 
   ACTIVITY_TYPES = {
     create_project: 0,
@@ -150,5 +154,5 @@ class Extends
     uncomplete_task: 54,
     assign_repository_record: 55,
     unassign_repository_record: 56
-  }
+  }.freeze
 end

--- a/db/migrate/20190227110801_remove_null_constraint_from_project_in_activities.rb
+++ b/db/migrate/20190227110801_remove_null_constraint_from_project_in_activities.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveNullConstraintFromProjectInActivities < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :activities, :project_id, :integer, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 
-ActiveRecord::Schema.define(version: 20190213064847) do
+ActiveRecord::Schema.define(version: 20190227110801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,7 @@ ActiveRecord::Schema.define(version: 20190213064847) do
     t.string "message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "project_id", null: false
+    t.bigint "project_id"
     t.bigint "experiment_id"
     t.string "subject_type"
     t.bigint "subject_id"

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -119,7 +119,7 @@ describe ProjectsController, type: :controller do
       end
 
       it 'never calls create activity service' do
-        expect(Activities::CreateActivityService).not_to receive(:call)
+        expect(Activities::CreateActivityService).to receive(:call)
 
         post :create, params: params, format: :json
       end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -117,6 +117,12 @@ describe ProjectsController, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity)
         expect(response.content_type).to eq 'application/json'
       end
+
+      it 'never calls create activity service' do
+        expect(Activities::CreateActivityService).not_to receive(:call)
+
+        post :create, params: params, format: :json
+      end
     end
   end
 

--- a/spec/factories/activities.rb
+++ b/spec/factories/activities.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
   factory :activity do
     type_of :create_project
     message Faker::Lorem.sentence(10)
-    project
     subject { create :project }
     owner { create :user }
     team

--- a/spec/factories/protocols.rb
+++ b/spec/factories/protocols.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :report do
-    user
-    project
-    team
+  factory :protocol do
     name { Faker::Name.unique.name }
+    team
+    my_module
   end
 end

--- a/spec/factories/results.rb
+++ b/spec/factories/results.rb
@@ -3,6 +3,7 @@
 FactoryBot.define do
   factory :result do
     name { Faker::Name.unique.name }
-    my_module { create(:my_module) }
+    my_module
+    user
   end
 end

--- a/spec/factories/steps.rb
+++ b/spec/factories/steps.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :step do
+    name { Faker::Name.unique.name }
+    position { Faker::Number.between(1, 10) }
+    completed { true }
+    user
+    protocol
+    completed_on { Time.now }
+  end
+end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -55,4 +55,12 @@ describe Activity, type: :model do
       expect(activity.old_activity?).to be_falsey
     end
   end
+
+  describe '.save' do
+    it 'adds user to message items' do
+      create :activity
+
+      expect(activity.message_items).to include(user: be_an(Hash))
+    end
+  end
 end

--- a/spec/models/report_spec.rb
+++ b/spec/models/report_spec.rb
@@ -39,9 +39,13 @@ describe Report, type: :model do
     end
 
     it 'should have uniq name scoped to user, project' do
-      create :report, name: 'Same Name'
-      new_rep = build :report, name: 'Same Name'
-      expect(new_rep).to_not be_valid
+      r = create :report, name: 'Same Name'
+      new_report = build :report,
+                         name: 'Same Name',
+                         user: r.user,
+                         project: r.project
+
+      expect(new_report).to_not be_valid
     end
   end
 end

--- a/spec/services/activities/create_activity_service_spec.rb
+++ b/spec/services/activities/create_activity_service_spec.rb
@@ -14,11 +14,114 @@ describe Activities::CreateActivityService do
             owner: user,
             subject: project,
             team: team,
-            project: project,
             message_items: { project: project.id })
   end
 
   it 'adds new activiy in DB' do
     expect { service_call }.to(change { Activity.count })
+  end
+
+  context 'enrich message items with values and types' do
+    before do
+      allow_any_instance_of(Activity).to receive(:save!).and_return(true)
+    end
+
+    context 'when there is no message items' do
+      it 'your message items remains empty' do
+        activity = Activities::CreateActivityService
+                   .call(activity_type: :create_project,
+                           owner: user,
+                           subject: project,
+                           team: team).activity
+
+        expect(activity.message_items).to be == {}
+      end
+    end
+
+    context 'when message item is simple string' do
+      it 'not transform message_item to hash' do
+        custom_call =
+          Activities::CreateActivityService
+          .call(activity_type: :create_project,
+                  owner: user,
+                  subject: project,
+                  team: team,
+                  message_items: { random_item: 'random_item_value' })
+
+        expect(custom_call.activity.message_items[:random_item])
+          .to be == 'random_item_value'
+      end
+
+      it 'adds string to message items' do
+        activity = Activities::CreateActivityService
+                   .call(activity_type: :create_project,
+                           owner: user,
+                           subject: project,
+                           team: team,
+                           message_items: {
+                             some_string: 'something'
+                           }).activity
+
+        expect(activity.message_items).to include(some_string: 'something')
+      end
+    end
+
+    context 'when message item is object' do
+      it 'transform message_item object to hash' do
+        a = service_call.activity
+
+        expect(a.message_items[:project].keys)
+          .to contain_exactly('type', 'value', 'id', 'value_for')
+      end
+
+      it 'adds object project to message items as hash' do
+        activity = Activities::CreateActivityService
+                   .call(activity_type: :create_project,
+                           owner: user,
+                           subject: project,
+                           team: team,
+                           message_items: {
+                             project: project.id
+                           }).activity
+        expect(activity.message_items).to include(project: be_an(Hash))
+      end
+    end
+
+    context 'when message item is object with diffrent name' do
+      it 'adds project_new to message items as hash' do
+        activity = Activities::CreateActivityService
+                   .call(activity_type: :create_project,
+                           owner: user,
+                           subject: project,
+                           team: team,
+                           message_items: {
+                             project_withsuffix: project.id
+                           }).activity
+        expect(activity.message_items)
+          .to include(project_withsuffix: be_an(Hash))
+      end
+    end
+
+    context 'when message item is an object with custom value getter' do
+      it 'adds project due date to message items as hash' do
+        project.update_attribute(:due_date, Date.tomorrow)
+
+        activity = Activities::CreateActivityService
+                   .call(activity_type: :create_project,
+                           owner: user,
+                           subject: project,
+                           team: team,
+                           message_items: {
+                             project_duedate: { id: project.id,
+                                                value_for: 'due_date' }
+                           }).activity
+
+        expect(activity.message_items)
+          .to include(project_duedate: { id: project.id,
+                                         type: 'Project',
+                                         value_for: 'due_date',
+                                         value: project.due_date.to_s })
+      end
+    end
   end
 end

--- a/spec/services/activities/create_activity_service_spec.rb
+++ b/spec/services/activities/create_activity_service_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Activities::CreateActivityService do
+  let(:user) { create :user }
+  let(:team) { create :team, :with_members }
+  let(:project) do
+    create :project, team: team, user_projects: []
+  end
+  let(:service_call) do
+    Activities::CreateActivityService
+      .call(activity_type: :create_project,
+            owner: user,
+            subject: project,
+            team: team,
+            project: project,
+            message_items: { project: project.id })
+  end
+
+  it 'adds new activiy in DB' do
+    expect { service_call }.to(change { Activity.count })
+  end
+end


### PR DESCRIPTION
Jira ticket: [SCI-3103](https://biosistemika.atlassian.net/browse/SCI-3103)

### What was done
- Service object for creating activities
- Tests for creating activities with different types of `message_items` - values 
- Add message_items params for call in excel document 

#### ToDo 
- @mlorb needs to finish her part
- add new `type_ofs`
- Check and update `.yml` strings where we need

#### Note:
This is part of reimplementation for creating activities.
I was trying to make service as flexible as we need to store different objects with different values and always have a fallback value (string value) for message item in case it's been deleted. 

If the code looks complex/ is not understandable enough, I can add some comments in the service file. Maybe is easier to understand with `rspec` descriptions. 

