### PR TITLE
Change line length in rubocop to 120

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -363,7 +363,7 @@ Metrics/CyclomaticComplexity:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 80
+  Max: 120
   AllowHeredoc: true
   AllowURI: true
   URISchemes:


### PR DESCRIPTION
Jira ticket: (none)

### What was done

Per @urbanrotnik, he suggested a more senseful line length limit would be 120 characters (than the current 80). Because now, any method parametrized with hashes is quickly more than 80 characters long.

#### ToDo:

Fix some other troubling issues with the Rubocop warnings.