### PR TITLE
Fix stack trace trimming on WOPI middleware

### DIFF
--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -3,5 +3,11 @@
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.
 # Rails.backtrace_cleaner.add_silencer { |line| line =~ /my_noisy_library/ }
 
+# Silence the WOPI method override to prevent "trapping" of stack/backtrace
+# See https://stackoverflow.com/questions/29498145
+Rails.backtrace_cleaner.add_silencer do |line|
+  line =~ %r{app/middlewares/wopi_method_override}
+end
+
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
 # Rails.backtrace_cleaner.remove_silencers!


### PR DESCRIPTION
Jira ticket: _none_

### What was done
Very often, when an `Exception` occurs in Rails, the WOPI middleware throttles it, and hides the original stack trace, and instead simply shows a simple log message:
```
app/middlewares/wopi_method_override.rb:17:in `call'
```

This fix aims to ignore the errors in the `wopi_method_override` middleware, and display a full stack trace.

### Note:

This should be tested, just to make sure some other logging is not silenced.