### PR TITLE
Step with Office Online files can be deleted, asset name is shown in activities screen [SCI-3279, 3283]

### DIFF
--- a/app/utilities/wopi_util.rb
+++ b/app/utilities/wopi_util.rb
@@ -96,7 +96,7 @@ module WopiUtil
         .call(activity_type: type_of,
               owner: current_user,
               subject: @protocol,
-              team: current_team,
+              team: @protocol.my_module.experiment.project.team,
               project: project,
               message_items: message_items)
     elsif @assoc.class == Result

--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -104,7 +104,7 @@ class Extends
   }.freeze
 
   ACTIVITY_MESSAGE_ITEMS_TYPES =
-    ACTIVITY_SUBJECT_TYPES + %w(User Tag RepositoryColumn RepositoryRow Step)
+    ACTIVITY_SUBJECT_TYPES + %w(User Tag RepositoryColumn RepositoryRow Step Asset)
     .freeze
 
   ACTIVITY_TYPES = {


### PR DESCRIPTION
Jira ticket: [SCI-3279](https://biosistemika.atlassian.net/browse/SCI-3279)
Jira ticket: [SCI-3283](https://biosistemika.atlassian.net/browse/SCI-3283)

### What was done
Fix non-existing variable in create wopi activity method. Add `Asset` to
acitvity subject types

### Note:
SCI-3279 can only be tested on my-test2.scinote.net.