### PR TITLE
Remove activities that belong to addons [SCI-3214]

### DIFF
--- a/config/initializers/extends.rb
+++ b/config/initializers/extends.rb
@@ -100,7 +100,7 @@ class Extends
     MyModule: [:results,:protocols],
     Result: nil,
     Protocol: [:steps],
-    Step: nil 
+    Step: nil
   }.freeze
 
   ACTIVITY_MESSAGE_ITEMS_TYPES =
@@ -173,10 +173,7 @@ class Extends
     remove_task_due_date: 63,
     add_task_tag: 64,
     edit_task_tag: 65,
-    remove_task_tag: 66,
-    sign_and_lock_task: 67,
-    cosign_and_lock_task: 68,
-    unlock_task: 69,
+    remove_task_tag: 66, # 67, 68, 69 are in addons
     create_inventory: 70,
     rename_inventory: 71,
     delete_inventory: 72,
@@ -203,18 +200,16 @@ class Extends
     remove_user_from_team: 93,
     change_users_role_on_team: 94,
     export_projects: 95,
-    export_inventory_items: 96,
-    export_audit_trails: 97,
-    export_system_logs: 98,
+    export_inventory_items: 96, # 97 is in addon
     edit_wopi_file_on_result: 99,
     edit_wopi_file_on_step: 100,
+    edit_wopi_file_on_step_in_repository: 101,
+    copy_inventory_item: 102,
     copy_protocol_in_repository: 103,
     user_leave_team: 104,
-    export_protocol_from_task: 106,
-    edit_wopi_file_on_step_in_repository: 101,
     copy_inventory: 105,
-    copy_inventory_item: 102
-  }.freeze
+    export_protocol_from_task: 106
+  }
 
   ACTIVITY_GROUPS = {
     projects: [*0..7, 32, 33, 34],
@@ -226,7 +221,6 @@ class Extends
     reports: [48, 49, 50],
     inventories: [*70..78, 105, 102],
     protocol_repository: [*79..91, 101, 103],
-    team: [*92..96, 104],
-    exports: [*97..98]
+    team: [*92..97, 104]
   }.freeze
 end

--- a/config/locales/global_activities/en.yml
+++ b/config/locales/global_activities/en.yml
@@ -198,9 +198,6 @@ en:
       add_task_tag: "Task tag added"
       edit_task_tag: "Task tag edited"
       remove_task_tag: "Task tag removed"
-      sign_and_lock_task: "Task signed and locked"
-      cosign_and_lock_task: "Task co-signed and locked"
-      unlock_task: "Task unlocked"
       create_inventory: "Inventory created"
       rename_inventory: "Inventory renamed"
       delete_inventory: "Inventory deleted"
@@ -232,8 +229,6 @@ en:
       user_leave_team: "User left team"
       export_projects: "Projects exported"
       export_inventory_items: "Inventory items exported"
-      export_audit_trails: "Audit trails exported"
-      export_system_logs: "System logs exported"
     activity_group:
       projects: "Projects"
       task_results: "Task results"


### PR DESCRIPTION
Jira ticket: [SCI-3214](https://biosistemika.atlassian.net/browse/SCI-3214)

Check also: [audit trails](https://gitlab.com/biosistemika/scinote/addons/audit_trails/merge_requests/33) and [electronic signatures](https://gitlab.com/biosistemika/scinote/addons/electronic_signatures/merge_requests/36)

### What was done
_Missing activities were implemented in addons (activities marked with blue color in sheet Missing activities in [Google spreadsheet](https://docs.google.com/spreadsheets/d/182zm7Q1it1U2ggQ9T28r3SKTnoFQFKiiE4hc9Io94Zc/edit?usp=sharing).)_

### Note:
_Activities that belong to addons were removed from core._
