### PR TITLE
Migrate emails from billing to common addons, update styling [SCI-3140]

### DIFF
--- a/test/mailers/previews/app_mailer_preview.rb
+++ b/test/mailers/previews/app_mailer_preview.rb
@@ -53,6 +53,7 @@ class AppMailerPreview < ActionMailer::Preview
     )
   end
 
+  # <b>DEPRECATED:</b> Please use <tt>system_notification</tt> instead.
   def system_message_notification
     AppMailer.notification(
       fake_user,

--- a/test/mailers/previews/app_mailer_preview.rb
+++ b/test/mailers/previews/app_mailer_preview.rb
@@ -7,10 +7,6 @@ class AppMailerPreview < ActionMailer::Preview
     AppMailer.reset_password_instructions(fake_user, 'faketoken', {})
   end
 
-  def unlock_instructions
-    AppMailer.unlock_instructions(fake_user, 'faketoken', {})
-  end
-
   def invitation_instructions
     AppMailer.invitation_instructions(fake_user, 'faketoken', {})
   end
@@ -44,7 +40,7 @@ class AppMailerPreview < ActionMailer::Preview
       Notification.new(
         type_of: :recent_changes,
         title: I18n.t(
-          'activities.create_module',
+          'global_activities.activity_name.create_module',
           user: user.full_name,
           module: 'How to shred'
         ),


### PR DESCRIPTION
Jira ticket: [SCI-3140](https://biosistemika.atlassian.net/browse/SCI-3140)

### What was done
* moved files from billing addon to common addon
* update styling of emails
* fix `export_db` rake task in billing addon

This is connected with:
* [billing addon PR](https://gitlab.com/biosistemika/scinote/addons/billing/merge_requests/76)
* [Common addon PR](https://gitlab.com/biosistemika/scinote/addons/Common/merge_requests/47)

### Note:
`invitation_mail` and `team_invitation_mail` appear plain in the previewer. I don't know the reasoning behind it, but when on production server it looks alright, at least it worked before the changes. So to avoid spending time what's going on, I suggest this is first tried on production server to see if it works as it is.


