### PR TITLE
Enable ScssLint 

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -3,3 +3,6 @@ PreCommit:
     enabled: true
     on_warn: fail
     problem_on_unmodified_line: ignore
+  ScssLint:
+    enabled: true
+    problem_on_unmodified_line: ignore


### PR DESCRIPTION
### What was done
Include ScssLint into a pre-commit hook with `overcommit`. 

I didn't figure out what `eslint` is not wokring in same way... ? 

