### PR TITLE
Disable editing of office file in view mode when module is locked [SCI-2949, 3318]

### DIFF
--- a/app/controllers/wopi_controller.rb
+++ b/app/controllers/wopi_controller.rb
@@ -325,7 +325,7 @@ class WopiController < ActionController::Base
       @breadcrumb_folder_url  = @close_url
     elsif @assoc.class == RepositoryCell
       @can_read = can_read_team?(@team)
-      @can_write = can_manage_repository_rows?(@team)
+      @can_write = can_edit_wopi_file_in_repository_rows?
 
       @close_url = repository_url(@repository,
                                   only_path: false,
@@ -363,5 +363,10 @@ class WopiController < ActionController::Base
   rescue => e
     logger.warn 'WOPI: proof verification: failed; ' + e.message
     render body: nil, status: 500 and return
+  end
+
+  # Overwrriten in electronic signature for locked inventory items
+  def can_edit_wopi_file_in_repository_rows?
+    can_manage_repository_rows?(@team)
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-2949](https://biosistemika.atlassian.net/browse/SCI-2949)
Jira ticket: [SCI-3318](https://biosistemika.atlassian.net/browse/SCI-3318)

This is connected to:
[Electronic signatures PR](https://gitlab.com/biosistemika/scinote/addons/electronic_signatures/merge_requests/37)

### What was done
Expose `@can_write` variable, so it can be overwritten in the addon.

### Note:
For the editing issue, it has to be first pushed onto the pro instance to test it.
