### PR TITLE
Rename button load more system notification to fix the bug [SCI-3331]

### DIFF
--- a/app/assets/javascripts/system_notifications/index.js
+++ b/app/assets/javascripts/system_notifications/index.js
@@ -33,7 +33,7 @@ function bindSystemNotificationAjax() {
 }
 
 function initSystemNotificationsButton() {
-  $('.btn-more-notifications')
+  $('.btn-more-system-notifications')
     .on('ajax:success', function(e, data) {
       $(data.html).insertAfter($('.system-notifications-container .system-notification').last());
       bindSystemNotificationAjax();

--- a/app/assets/stylesheets/system_notifications.scss
+++ b/app/assets/stylesheets/system_notifications.scss
@@ -116,7 +116,7 @@
     }
   }
 
-  .btn-more-notifications {
+  .btn-more-system-notifications {
     margin-top: 10px;
   }
 }

--- a/app/views/system_notifications/index.html.erb
+++ b/app/views/system_notifications/index.html.erb
@@ -22,7 +22,7 @@
   </div>
   <div class="text-center">
   <% if @system_notifications[:more_notifications_url] && @system_notifications[:notifications].present? %>
-      <a class="btn btn-default btn-more-notifications"
+      <a class="btn btn-default btn-more-system-notifications"
           href="<%= @system_notifications[:more_notifications_url] %>"
           data-remote="true">
           <%= t("system_notifications.index.more_notifications") %></a>


### PR DESCRIPTION
Jira ticket: [SCI-3331](https://biosistemika.atlassian.net/browse/SCI-3331)

### What was done
_The button for loading more system notifications was renamed, because it was called also when the button in "general" notification was clicked._

#### ToDo:
_Fix "Show more notification" button not being shown._
