### PR TITLE
Remove unused devise_security_extension dependency [SCI-3347]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,9 +96,6 @@ gem 'tinymce-rails', '~> 4.7.13' # Rich text editor - SEE BELOW
 # TinyMCE files which might cause errors
 
 gem 'base62' # Used for smart annotations
-gem 'devise_security_extension',
-    git: 'https://github.com/phatworx/devise_security_extension.git',
-    ref: 'b2ee978'
 gem 'newrelic_rpm'
 
 # Permission helper Gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,15 +39,6 @@ GIT
     devise-async (0.10.2)
       devise (>= 4.0)
 
-GIT
-  remote: https://github.com/phatworx/devise_security_extension.git
-  revision: b2ee978af7d49f0fb0e7271c6ac074dfb4d39353
-  ref: b2ee978
-  specs:
-    devise_security_extension (0.10.0)
-      devise (>= 3.0.0, < 5.0)
-      railties (>= 3.2.6, < 6.0)
-
 GEM
   remote: http://rubygems.org/
   specs:
@@ -596,7 +587,6 @@ DEPENDENCIES
   devise (~> 4.3.0)
   devise-async!
   devise_invitable
-  devise_security_extension!
   discard (~> 1.0)
   doorkeeper (>= 4.6)
   factory_bot_rails


### PR DESCRIPTION
Jira ticket: [SCI-3347](https://biosistemika.atlassian.net/browse/SCI-3347)

### What was done
Remove unused and outdated devise_security_extension dependency

