### PR TITLE
Bulk insert for SystemNotifications, updated ordering [SCI-3346]

### DIFF
--- a/app/models/system_notification.rb
+++ b/app/models/system_notification.rb
@@ -30,7 +30,7 @@ class SystemNotification < ApplicationRecord
     user,
     query = nil
   )
-    notifications = order(last_time_changed_at: :DESC)
+    notifications = order(created_at: :DESC)
     notifications = notifications.search_notifications(query) if query.present?
     notifications.joins(:user_system_notifications)
                  .where('user_system_notifications.user_id = ?', user.id)
@@ -39,6 +39,7 @@ class SystemNotification < ApplicationRecord
                    :title,
                    :description,
                    :last_time_changed_at,
+                   :created_at,
                    'user_system_notifications.seen_at',
                    'user_system_notifications.read_at'
                  )

--- a/app/models/system_notification.rb
+++ b/app/models/system_notification.rb
@@ -51,6 +51,6 @@ class SystemNotification < ApplicationRecord
     SystemNotification
       .order(last_time_changed_at: :desc)
       .first&.last_time_changed_at&.to_i ||
-      User.order(created_at: :desc).first&.created_at&.to_i
+      User.order(created_at: :asc).first&.created_at&.to_i
   end
 end

--- a/app/models/user_system_notification.rb
+++ b/app/models/user_system_notification.rb
@@ -24,14 +24,15 @@ class UserSystemNotification < ApplicationRecord
     # for notification check leave update_read_time empty
     notification = joins(:system_notification)
                    .where('system_notifications.show_on_login = true')
-                   .order('system_notifications.last_time_changed_at DESC')
+                   .order('system_notifications.created_at DESC')
                    .select(
                      :modal_title,
                      :modal_body,
                      'user_system_notifications.id',
                      :read_at,
                      :user_id,
-                     :system_notification_id
+                     :system_notification_id,
+                     :created_at
                    )
                    .first
     if notification && notification.read_at.nil?

--- a/app/models/user_system_notification.rb
+++ b/app/models/user_system_notification.rb
@@ -4,8 +4,7 @@ class UserSystemNotification < ApplicationRecord
   belongs_to :user
   belongs_to :system_notification
 
-  after_create :send_email,
-               if: proc { |sn| sn.user.system_message_email_notification }
+  validates :system_notification, uniqueness: { scope: :user }
 
   scope :unseen, -> { where(seen_at: nil) }
 
@@ -15,9 +14,7 @@ class UserSystemNotification < ApplicationRecord
 
   def self.mark_as_read(notification_id)
     notification = find_by_system_notification_id(notification_id)
-    if notification && notification.read_at.nil?
-      notification.update(read_at: Time.now)
-    end
+    notification.update(read_at: Time.now) if notification && notification.read_at.nil?
   end
 
   def self.show_on_login(update_read_time = false)
@@ -44,11 +41,5 @@ class UserSystemNotification < ApplicationRecord
       end
       notification
     end
-  end
-
-  private
-
-  def send_email
-    AppMailer.delay.system_notification(user, system_notification)
   end
 end

--- a/app/services/notifications/handle_system_notification_in_communication_channel_service.rb
+++ b/app/services/notifications/handle_system_notification_in_communication_channel_service.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Notifications
+  class HandleSystemNotificationInCommunicationChannelService
+    extend Service
+
+    attr_reader :errors
+
+    def initialize(system_notification)
+      @system_notification = system_notification
+      @errors = {}
+    end
+
+    def call
+      @system_notification.user_system_notifications.find_each do |usn|
+        user = usn.user
+        AppMailer.delay.system_notification(user, @system_notification) if user.system_message_email_notification
+      end
+
+      self
+    end
+
+    def succeed?
+      @errors.none?
+    end
+  end
+end

--- a/app/services/notifications/push_to_communication_channel_service.rb
+++ b/app/services/notifications/push_to_communication_channel_service.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Notifications
+  class PushToCommunicationChannelService
+    extend Service
+
+    WHITELISTED_ITEM_TYPES = %w(SystemNotification).freeze
+
+    attr_reader :errors
+
+    def initialize(item_id:, item_type:)
+      @item_type = item_type
+      @item = item_type.constantize.find item_id
+      @errors = {}
+    end
+
+    def call
+      return self unless valid?
+
+      "Notifications::Handle#{@item_type}InCommunicationChannelService".constantize.call(@item)
+      self
+    end
+
+    def succeed?
+      @errors.none?
+    end
+
+    private
+
+    def valid?
+      raise 'Dont know how to handle this type of items' unless WHITELISTED_ITEM_TYPES.include?(@item_type)
+
+      if @item.nil?
+        @errors[:invalid_arguments] = 'Can\'t find item' if @item.nil?
+        return false
+      end
+      true
+    end
+  end
+end

--- a/app/views/system_notifications/_notification.html.erb
+++ b/app/views/system_notifications/_notification.html.erb
@@ -12,7 +12,7 @@
   </div>
   <div class="body-block">
     <div class="datetime">
-      <span><%= l(notification.last_time_changed_at, format: :full) %></span>
+      <span><%= l(notification.created_at, format: :full) %></span>
     </div>
     <h5 class="title">
       <%= notification.title %>

--- a/db/migrate/20190424113216_add_unique_index_to_system_notifications.rb
+++ b/db/migrate/20190424113216_add_unique_index_to_system_notifications.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexToSystemNotifications < ActiveRecord::Migration[5.1]
+  def change
+    # remove not unique index and add new with uniq
+    remove_index :system_notifications, :source_id
+    add_index :system_notifications, :source_id, unique: true
+
+    add_index :user_system_notifications, %i(user_id system_notification_id), unique: true,
+              name: 'index_user_system_notifications_on_user_and_notification_id'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190410110605) do
+ActiveRecord::Schema.define(version: 20190424113216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -684,7 +684,7 @@ ActiveRecord::Schema.define(version: 20190410110605) do
     t.datetime "updated_at", null: false
     t.index ["last_time_changed_at"], name: "index_system_notifications_on_last_time_changed_at"
     t.index ["source_created_at"], name: "index_system_notifications_on_source_created_at"
-    t.index ["source_id"], name: "index_system_notifications_on_source_id"
+    t.index ["source_id"], name: "index_system_notifications_on_source_id", unique: true
   end
 
   create_table "tables", force: :cascade do |t|
@@ -819,6 +819,7 @@ ActiveRecord::Schema.define(version: 20190410110605) do
     t.index ["read_at"], name: "index_user_system_notifications_on_read_at"
     t.index ["seen_at"], name: "index_user_system_notifications_on_seen_at"
     t.index ["system_notification_id"], name: "index_user_system_notifications_on_system_notification_id"
+    t.index ["user_id", "system_notification_id"], name: "index_user_system_notifications_on_user_and_notification_id", unique: true
     t.index ["user_id"], name: "index_user_system_notifications_on_user_id"
   end
 

--- a/spec/factories/system_notifications.rb
+++ b/spec/factories/system_notifications.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     modal_title { Faker::Name.first_name }
     modal_body { Faker::Lorem.paragraphs(4).map { |pr| "<p>#{pr}</p>" }.join }
     source_created_at { Faker::Time.between(3.days.ago, Date.today) }
-    source_id { Faker::Number.between(1, 1000) }
+    source_id { SystemNotification.order(source_id: :desc).first&.source_id.to_i + 1 }
     last_time_changed_at { Time.now }
     trait :show_on_login do
       show_on_login { true }

--- a/spec/models/system_notification_spec.rb
+++ b/spec/models/system_notification_spec.rb
@@ -56,11 +56,12 @@ describe SystemNotification do
     end
 
     context 'when there is no system notifications in db' do
-      it 'returns last user created_at' do
+      it 'returns first users created_at' do
         create :user
+        create :user, created_at: Time.now + 5.seconds
 
         expect(described_class.last_sync_timestamp)
-          .to be == User.last.created_at.to_i
+          .to be == User.first.created_at.to_i
       end
     end
 

--- a/spec/models/user_system_notification_spec.rb
+++ b/spec/models/user_system_notification_spec.rb
@@ -15,36 +15,6 @@ describe UserSystemNotification do
     it { is_expected.to belong_to(:system_notification) }
   end
 
-  describe '.create' do
-    before do
-      Delayed::Worker.delay_jobs = false
-    end
-
-    after do
-      Delayed::Worker.delay_jobs = true
-    end
-
-    context 'when user has enabled notifications' do
-      it 'calls send an email on creation' do
-        allow(user_system_notification.user)
-          .to receive(:system_message_email_notification).and_return(true)
-
-        expect(user_system_notification).to receive(:send_email)
-        user_system_notification.save
-      end
-    end
-
-    context 'when user has disabled notifications' do
-      it 'doesn\'t call send an email on createion' do
-        allow(user_system_notification.user)
-          .to receive(:system_message_email_notification).and_return(false)
-
-        expect(user_system_notification).not_to receive(:send_email)
-        user_system_notification.save
-      end
-    end
-  end
-
   describe 'Methods' do
     let(:notifcation_one) { create :system_notification }
     let(:notifcation_two) { create :system_notification }

--- a/spec/services/notifications/handle_system_notification_in_communication_channel_service_spec.rb
+++ b/spec/services/notifications/handle_system_notification_in_communication_channel_service_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Notifications::HandleSystemNotificationInCommunicationChannelService do
+  let(:system_notification) { create :system_notification }
+  let!(:user_system_notification) do
+    create :user_system_notification, user: user, system_notification: system_notification
+  end
+  let(:user) { create :user }
+  let(:service_call) do
+    Notifications::HandleSystemNotificationInCommunicationChannelService.call(system_notification)
+  end
+
+  before do
+    Delayed::Worker.delay_jobs = false
+  end
+
+  after do
+    Delayed::Worker.delay_jobs = true
+  end
+
+  context 'when user has enabled notifications' do
+    it 'calls AppMailer' do
+      allow_any_instance_of(User).to receive(:system_message_email_notification).and_return(true)
+
+      expect(AppMailer).to receive(:system_notification).and_return(double('Mailer', deliver: true))
+
+      service_call
+    end
+  end
+
+  context 'when user has disabled notifications' do
+    it 'does not call AppMailer' do
+      allow_any_instance_of(User).to receive(:system_message_email_notification).and_return(false)
+
+      expect(AppMailer).not_to receive(:system_notification)
+
+      service_call
+    end
+  end
+end

--- a/spec/services/notifications/push_to_communication_channel_service_spec.rb
+++ b/spec/services/notifications/push_to_communication_channel_service_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Notifications::PushToCommunicationChannelService do
+  let(:system_notification) { create :system_notification }
+  let(:service_call) do
+    Notifications::PushToCommunicationChannelService.call(item_id: system_notification.id,
+                                                          item_type: system_notification.class.name)
+  end
+
+  context 'when call with valid items' do
+    it 'call service to to handle sending out' do
+      expect(Notifications::HandleSystemNotificationInCommunicationChannelService)
+        .to receive(:call).with(system_notification)
+
+      service_call
+    end
+  end
+
+  context 'when call with not valid items' do
+    it 'returns error with key invalid_arguments when system notification not exists' do
+      allow(SystemNotification).to receive(:find).and_return(nil)
+
+      expect(service_call.errors).to have_key(:invalid_arguments)
+    end
+
+    it 'raise error when have not listed object' do
+      u = create :user
+
+      expect do
+        Notifications::PushToCommunicationChannelService.call(item_id: u.id, item_type: 'User')
+      end.to(raise_error('Dont know how to handle this type of items'))
+    end
+  end
+end


### PR DESCRIPTION
Jira ticket: [SCI-3346](https://biosistemika.atlassian.net/browse/SCI-3346)

### What was done
- update ordering (from `last_time_changed_at` to `created_at`) 
- Bulk insert with `active_record-import`
- Add unique constraint for `source_id` (prevent save more than 1 same notification in DB when more than 1 worker) 
- Removed callback `after_commit` and send emails with an explicit call
- Add service object for notifying users. With @radiokills we agreed to add extendable service/class for sending emails and we can reuse it for upcoming feature "notifications".

### Note:
I tested sending (and receiving) notifications on my local machine with 100k users, received 6 notifications at once. Tested also with more than one job at once. 