### PR TITLE
Implement API client for protocols.io [SCI-3357]

### DIFF
--- a/app/utilities/protocol_importers/protocols_io/v3/api_client.rb
+++ b/app/utilities/protocol_importers/protocols_io/v3/api_client.rb
@@ -1,0 +1,67 @@
+module ProtocolImporters
+  module ProtocolsIO
+    module V3
+      class ApiClient
+        include HTTParty
+
+        base_uri 'https://www.protocols.io/api/v3/'
+        default_timeout 10
+
+        def initialize(token = nil)
+          # Currently we support public tokens only (no token needed for public data)
+          @auth = { token: token }
+
+          # Set default headers
+          self.class.headers('Authorization': "Bearer #{@auth[:token]}") if @auth[:token].present?
+        end
+
+        # Query params available are:
+        #   filter (optional): {public|user_public|user_private|shared_with_user}
+        #     Which type of protocols to filter.
+        #     default is public and requires no auth token.
+        #     user_public requires public token.
+        #     user_private|shared_with_user require private auth token.
+        #   key (optional): string
+        #     Search key to search for in protocol name, description, authors.
+        #     default: ''
+        #   order_field (optional): {activity|date|name|id}
+        #     order by this field.
+        #     default is activity.
+        #   order_dir (optional): {desc|asc}
+        #     Direction of ordering.
+        #     default is desc.
+        #   page_size (optional): int
+        #     Number of items per page.
+        #     Default 10.
+        #   page_id (optional): int (1..n)
+        #     id of page.
+        #     Default is 1.
+        def protocol_list(query_params = {})
+          query = {
+            filter: :public,
+            key: '',
+            order_field: :activity,
+            order_dir: :desc,
+            page_size: 10,
+            page_id: 1
+          }.merge!(query_params)
+
+          self.class.get('/protocols', query: query)
+        end
+
+        # Returns full representation of given protocol ID
+        def single_protocol(id)
+          self.class.get("/protocols/#{id}")
+        end
+
+        # Returns html preview for given protocol
+        # This endpoint is outside the scope of API but is listed here for the
+        # sake of clarity
+        def protocol_html_preview(uri)
+          self.class.get("https://www.protocols.io/view/#{uri}.html", headers: {})
+        end
+      end
+
+    end
+  end
+end

--- a/app/utilities/protocol_importers/protocols_io/v3/api_client.rb
+++ b/app/utilities/protocol_importers/protocols_io/v3/api_client.rb
@@ -6,9 +6,11 @@ module ProtocolImporters
       class ApiClient
         include HTTParty
 
-        base_uri 'https://www.protocols.io/api/v3/'
-        default_timeout 10
-        logger Rails.logger, :debug
+        CONSTANTS = Constants::PROTOCOLS_IO_V3_API
+
+        base_uri CONSTANTS[:base_uri]
+        default_timeout CONSTANTS[:default_timeout]
+        logger Rails.logger, CONSTANTS[:debug_level]
 
         def initialize(token = nil)
           # Currently we support public tokens only (no token needed for public data)
@@ -40,14 +42,8 @@ module ProtocolImporters
         #     id of page.
         #     Default is 1.
         def protocol_list(query_params = {})
-          query = {
-            filter: :public,
-            key: '',
-            order_field: :activity,
-            order_dir: :desc,
-            page_size: 10,
-            page_id: 1
-          }.merge!(query_params)
+          query = CONSTANTS.dig(:endpoints, :protocols, :default_query_params)
+                           .merge(query_params)
 
           self.class.get('/protocols', query: query)
         end

--- a/app/utilities/protocol_importers/protocols_io/v3/api_client.rb
+++ b/app/utilities/protocol_importers/protocols_io/v3/api_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ProtocolImporters
   module ProtocolsIO
     module V3
@@ -6,6 +8,7 @@ module ProtocolImporters
 
         base_uri 'https://www.protocols.io/api/v3/'
         default_timeout 10
+        logger Rails.logger, :debug
 
         def initialize(token = nil)
           # Currently we support public tokens only (no token needed for public data)
@@ -61,7 +64,6 @@ module ProtocolImporters
           self.class.get("https://www.protocols.io/view/#{uri}.html", headers: {})
         end
       end
-
     end
   end
 end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -184,6 +184,28 @@ class Constants
   DEFAULT_AVATAR_URL = '/images/:style/missing.png'.freeze
 
   #=============================================================================
+  # Protocol importers
+  #=============================================================================
+
+  PROTOCOLS_IO_V3_API = {
+    base_uri: 'https://www.protocols.io/api/v3/',
+    default_timeout: 10,
+    debug_level: :debug,
+    endpoints: {
+      protocols: {
+        default_query_params: {
+          filter: :public,
+          key: '',
+          order_field: :activity,
+          order_dir: :desc,
+          page_size: 10,
+          page_id: 1
+        }
+      }
+    }
+  }.freeze
+
+  #=============================================================================
   # Other
   #=============================================================================
 

--- a/spec/utilities/protocol_importers/protocols_io/v3/api_client_spec.rb
+++ b/spec/utilities/protocol_importers/protocols_io/v3/api_client_spec.rb
@@ -3,24 +3,18 @@
 require 'rails_helper'
 
 describe ProtocolImporters::ProtocolsIO::V3::ApiClient do
+  CONSTANTS = Constants::PROTOCOLS_IO_V3_API
   TOKEN = 'test_token'
 
   describe '#protocol_list' do
-    URL = 'https://www.protocols.io/api/v3/protocols'
+    URL = "#{CONSTANTS[:base_uri]}protocols"
 
     let(:stub_protocols) do
       stub_request(:get, URL).with(query: hash_including({}))
     end
 
     let(:default_query_params) do
-      {
-        filter: :public,
-        key: '',
-        order_dir: :desc,
-        order_field: :activity,
-        page_id: 1,
-        page_size: 10
-      }
+      CONSTANTS.dig(:endpoints, :protocols, :default_query_params)
     end
 
     it 'returns 200 on successfull call' do
@@ -69,7 +63,7 @@ describe ProtocolImporters::ProtocolsIO::V3::ApiClient do
 
   describe '#single_protocol' do
     PROTOCOL_ID = 15
-    SINGLE_PROTOCOL_URL = "https://www.protocols.io/api/v3/protocols/#{PROTOCOL_ID}"
+    SINGLE_PROTOCOL_URL = "#{CONSTANTS[:base_uri]}protocols/#{PROTOCOL_ID}"
 
     let(:stub_single_protocol) do
       stub_request(:get, SINGLE_PROTOCOL_URL)

--- a/spec/utilities/protocol_importers/protocols_io/v3/api_client_spec.rb
+++ b/spec/utilities/protocol_importers/protocols_io/v3/api_client_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe ProtocolImporters::ProtocolsIO::V3::ApiClient do
+  TOKEN = 'test_token'
+
+  describe '#protocol_list' do
+    URL = 'https://www.protocols.io/api/v3/protocols'
+
+    let(:stub_protocols) do
+      stub_request(:get, URL).with(query: hash_including({}))
+    end
+
+    let(:default_query_params) do
+      {
+        filter: :public,
+        key: '',
+        order_dir: :desc,
+        order_field: :activity,
+        page_id: 1,
+        page_size: 10
+      }
+    end
+
+    it 'returns 200 on successfull call' do
+      stub_protocols.to_return(status: 200, body: '[]', headers: {})
+
+      expect(subject.protocol_list.code).to eq 200
+      expect(stub_protocols).to have_been_requested
+    end
+
+    it 'raises OpenTimeout error on timeout' do
+      stub_protocols.to_timeout
+
+      expect { subject.protocol_list }.to raise_error(Net::OpenTimeout)
+    end
+
+    it 'requests server with default query parameters if none are given' do
+      stub_request(:get, URL).with(query: default_query_params)
+
+      subject.protocol_list
+      expect(WebMock).to have_requested(:get, URL).with(query: default_query_params)
+    end
+
+    it 'requests server with given query parameters' do
+      query = {
+        filter: :user_public,
+        key: 'banana',
+        order_dir: :asc,
+        order_field: :date,
+        page_id: 2,
+        page_size: 15
+      }
+      stub_request(:get, URL).with(query: query)
+
+      subject.protocol_list(query)
+      expect(WebMock).to have_requested(:get, URL).with(query: query)
+    end
+
+    it 'should send authorization token if provided on initialization' do
+      headers = { 'Authorization': "Bearer #{TOKEN}" }
+      stub_request(:get, URL).with(headers: headers, query: default_query_params)
+
+      ProtocolImporters::ProtocolsIO::V3::ApiClient.new(TOKEN).protocol_list
+      expect(WebMock).to have_requested(:get, URL).with(headers: headers, query: default_query_params)
+    end
+  end
+
+  describe '#single_protocol' do
+    PROTOCOL_ID = 15
+    SINGLE_PROTOCOL_URL = "https://www.protocols.io/api/v3/protocols/#{PROTOCOL_ID}"
+
+    let(:stub_single_protocol) do
+      stub_request(:get, SINGLE_PROTOCOL_URL)
+    end
+
+    it 'returns 200 on successfull call' do
+      stub_single_protocol.to_return(status: 200, body: '[]', headers: {})
+
+      expect(subject.single_protocol(PROTOCOL_ID).code).to eq 200
+      expect(stub_single_protocol).to have_been_requested
+    end
+
+    it 'raises OpenTimeout error on timeout' do
+      stub_single_protocol.to_timeout
+
+      expect { subject.single_protocol(PROTOCOL_ID) }.to raise_error(Net::OpenTimeout)
+    end
+
+    it 'should send authorization token if provided on initialization' do
+      headers = { 'Authorization': "Bearer #{TOKEN}" }
+      stub_single_protocol.with(headers: headers)
+
+      ProtocolImporters::ProtocolsIO::V3::ApiClient.new(TOKEN).single_protocol(PROTOCOL_ID)
+      expect(WebMock).to have_requested(:get, SINGLE_PROTOCOL_URL).with(headers: headers)
+    end
+  end
+
+  describe '#protocol_html_preview' do
+    PROTOCOL_URI = 'Extracting-DNA-from-bananas-esvbee6'
+
+    let(:stub_html_preview) do
+      stub_request(:get, "https://www.protocols.io/view/#{PROTOCOL_URI}.html")
+    end
+
+    it 'returns 200 on successfull call' do
+      stub_html_preview.to_return(status: 200, body: '[]', headers: {})
+
+      expect(subject.protocol_html_preview(PROTOCOL_URI).code).to eq 200
+      expect(stub_html_preview).to have_been_requested
+    end
+
+    it 'raises OpenTimeout error on timeout' do
+      stub_html_preview.to_timeout
+
+      expect { subject.protocol_html_preview(PROTOCOL_URI) }.to raise_error(Net::OpenTimeout)
+    end
+  end
+end


### PR DESCRIPTION
Closes SCI-3357

Jira ticket: [SCI-3357](https://biosistemika.atlassian.net/browse/SCI-3357)

### What was done
Implement API client for protocols.io to be used in future classes.

### Note:
I opted not to include connection errors in this class. It would be better handled in normalizer for user to get feedback.
