### PR TITLE
Add editnew action for editing new office files [SCI-3380]

### DIFF
--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -128,8 +128,9 @@ class AssetsController < ApplicationController
   end
 
   def edit
+    action = @asset.file_file_size.zero? && !@asset.locked? ? 'editnew' : 'edit'
     @action_url = append_wd_params(@asset
-                                   .get_action_url(current_user, 'edit', false))
+                                  .get_action_url(current_user, action, false))
     @favicon_url = @asset.favicon_url('edit')
     tkn = current_user.get_wopi_token
     @token = tkn.token

--- a/app/utilities/wopi_util.rb
+++ b/app/utilities/wopi_util.rb
@@ -55,7 +55,8 @@ module WopiUtil
       wopi_app.save!
       app.xpath('action').each do |action|
         name = action.xpath('@name').first.value
-        next unless %w(view edit wopitest).include?(name)
+        next unless %w(view edit editnew wopitest).include?(name)
+
         wopi_action = WopiAction.new
         wopi_action.action = name
         wopi_action.extension = action.xpath('@ext').first.value


### PR DESCRIPTION
Jira ticket: [SCI-3380](https://biosistemika.atlassian.net/browse/SCI-3380)

### What was done
Add `editnew` action for opening zero-byte MS Office files.

### Note:
One has to destroy all old `WopiAction` that are cached in DB otherwise this will not work, since the old action have no `editnew` action. Available on my-test2 ENV.
