### PR TITLE
Force UTF-8 encoding for Table contents in API [SCI-3376]

### DIFF
--- a/app/serializers/api/v1/result_table_serializer.rb
+++ b/app/serializers/api/v1/result_table_serializer.rb
@@ -11,7 +11,7 @@ module Api
       end
 
       def table_contents
-        object.table&.contents
+        object.table&.contents&.force_encoding(Encoding::UTF_8)
       end
     end
   end


### PR DESCRIPTION
Jira ticket: [SCI-3376](https://biosistemika.atlassian.net/browse/SCI-3376)

### What was done
Force UTF-8 encoding for Table contents in API