### PR TITLE
Fix nil handling in different places [SCI-2840]

### DIFF
--- a/app/assets/javascripts/my_modules.js
+++ b/app/assets/javascripts/my_modules.js
@@ -298,7 +298,10 @@ function initTagsSelector() {
     var selectElement = e.target;
     if (params.id > 0) {
       newTag = { my_module_tag: { tag_id: e.params.data.id } };
-      $.post($('#module-tags-selector')[0].dataset.updateModuleTagsUrl, newTag);
+      $.post($('#module-tags-selector')[0].dataset.updateModuleTagsUrl, newTag)
+        .fail(function() {
+          $('.module-tags .select2-selection__choice').last().remove();
+        });
     } else {
       newTag = {
         tag: {

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -305,12 +305,9 @@ class AssetsController < ApplicationController
   end
 
   def append_wd_params(url)
-    wd_params = ''
-    params.keys.select { |i| i[/^wd.*/] }.each do |wd|
-      next if wd == 'wdPreviousSession' || wd == 'wdPreviousCorrelation'
-      wd_params += "&#{wd}=#{params[wd]}"
-    end
-    url + wd_params
+    exclude_params = %i(wdPreviousSession wdPreviousCorrelation)
+    wd_params = params.select { |key, _value| key[/^wd.*/] && !(exclude_params.include? key) }.to_query
+    url + '&' + wd_params
   end
 
   def asset_params

--- a/app/controllers/my_module_tags_controller.rb
+++ b/app/controllers/my_module_tags_controller.rb
@@ -55,10 +55,7 @@ class MyModuleTagsController < ApplicationController
   end
 
   def create
-    unless mt_params[:tag_id]
-      render_403
-      return false
-    end
+    return render_403 unless mt_params[:tag_id]
 
     @mt = MyModuleTag.new(mt_params.merge(my_module: @my_module))
     @mt.created_by = current_user
@@ -89,10 +86,7 @@ class MyModuleTagsController < ApplicationController
   def destroy
     @mt = MyModuleTag.find_by_id(params[:id])
 
-    unless @mt
-      render_404
-      return false
-    end
+    return render_404 unless @mt
 
     Activities::CreateActivityService
       .call(activity_type: :remove_task_tag,

--- a/app/controllers/my_module_tags_controller.rb
+++ b/app/controllers/my_module_tags_controller.rb
@@ -55,11 +55,17 @@ class MyModuleTagsController < ApplicationController
   end
 
   def create
+    unless mt_params[:tag_id]
+      render_403
+      return false
+    end
+
     @mt = MyModuleTag.new(mt_params.merge(my_module: @my_module))
     @mt.created_by = current_user
     @mt.save
 
     my_module = @mt.my_module
+
     Activities::CreateActivityService
       .call(activity_type: :add_task_tag,
             owner: current_user,
@@ -82,6 +88,11 @@ class MyModuleTagsController < ApplicationController
 
   def destroy
     @mt = MyModuleTag.find_by_id(params[:id])
+
+    unless @mt
+      render_404
+      return false
+    end
 
     Activities::CreateActivityService
       .call(activity_type: :remove_task_tag,

--- a/app/controllers/step_comments_controller.rb
+++ b/app/controllers/step_comments_controller.rb
@@ -132,9 +132,9 @@ class StepCommentsController < ApplicationController
     @last_comment_id = params[:from].to_i
     @per_page = Constants::COMMENTS_SEARCH_LIMIT
     @step = Step.find_by_id(params[:step_id])
-    @protocol = @step.protocol
+    @protocol = @step&.protocol
 
-    unless @step
+    unless @step && @protocol
       render_404
     end
   end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -514,7 +514,7 @@ class StepsController < ApplicationController
 
   def load_vars
     @step = Step.find_by_id(params[:id])
-    @protocol = @step.protocol
+    @protocol = @step&.protocol
     if params[:checklistitem_id]
       @chk_item = ChecklistItem.find_by_id(params[:checklistitem_id])
     end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -69,15 +69,11 @@ module Users
         end
 
         result = { email: email }
-
-        if !(Constants::BASIC_EMAIL_REGEX === email) ||
-           validate_user(email, email, generate_user_password).count.positive?
-
+        unless Constants::BASIC_EMAIL_REGEX === email
           result[:status] = :user_invalid
           @invite_results << result
           next
         end
-
         # Check if user already exists
         user = User.find_by_email(email)
 
@@ -121,7 +117,6 @@ module Users
               user_team.role_str,
               user_team.team
             )
-
             Activities::CreateActivityService
               .call(activity_type: :invite_user_to_team,
                     owner: current_user,

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Users
   class InvitationsController < Devise::InvitationsController
     include InputSanitizeHelper
@@ -13,6 +15,7 @@ module Users
 
     def update
       return super unless Rails.configuration.x.new_team_on_signup
+
       # Instantialize a new team with the provided name
       @team = Team.new
       @team.name = params[:team][:name]
@@ -59,58 +62,49 @@ module Users
       @invite_results = []
       @too_many_emails = false
 
-      cntr = 0
-      @emails.each do |email|
-        cntr += 1
-
-        if cntr > Constants::INVITE_USERS_LIMIT
+      @emails.each_with_index do |email, count|
+        if (count + 1) > Constants::INVITE_USERS_LIMIT
           @too_many_emails = true
           break
         end
 
-        password = generate_user_password
-
-        # Check if user already exists
-        user = nil
-        user = User.find_by_email(email) if User.exists?(email: email)
-
         result = { email: email }
 
-        if user.present?
+        if !(Constants::BASIC_EMAIL_REGEX === email) ||
+           validate_user(email, email, generate_user_password).count.positive?
+
+          result[:status] = :user_invalid
+          @invite_results << result
+          next
+        end
+
+        # Check if user already exists
+        user = User.find_by_email(email)
+
+        if user
           result[:status] = :user_exists
           result[:user] = user
         else
-          # Validate the user data
-          error = !(Constants::BASIC_EMAIL_REGEX === email)
-          error = validate_user(email, email, password).count > 0 unless error
+          user = User.invite!(
+            full_name: email,
+            email: email,
+            initials: email.upcase[0..1],
+            skip_invitation: true
+          )
+          user.update(invited_by: @user)
 
-          if !error
-            user = User.invite!(
-              full_name: email,
-              email: email,
-              initials: email.upcase[0..1],
-              skip_invitation: true
-            )
-            user.update(invited_by: @user)
+          result[:status] = :user_created
+          result[:user] = user
 
-            result[:status] = :user_created
-            result[:user] = user
-
-            # Sending email invitation is done in background job to prevent
-            # issues with email delivery. Also invite method must be call
-            # with :skip_invitation attribute set to true - see above.
-            user.delay.deliver_invitation
-          else
-            # Return invalid status
-            result[:status] = :user_invalid
-          end
+          # Sending email invitation is done in background job to prevent
+          # issues with email delivery. Also invite method must be call
+          # with :skip_invitation attribute set to true - see above.
+          user.delay.deliver_invitation
         end
 
-        if @team.present? && result[:status] != :user_invalid
-          if UserTeam.exists?(user: user, team: @team)
-            user_team =
-              UserTeam.where(user: user, team: @team).first
-
+        if @team && user
+          user_team = UserTeam.find_by_user_id_and_team_id(user.id, @team.id)
+          if user_team
             result[:status] = :user_exists_and_in_team
           else
             # Also generate user team relation
@@ -139,13 +133,13 @@ module Users
                       role: user_team.role_str
                     })
 
-            if result[:status] == :user_exists && !user.confirmed?
-              result[:status] = :user_exists_unconfirmed_invited_to_team
-            elsif result[:status] == :user_exists
-              result[:status] = :user_exists_invited_to_team
-            else
-              result[:status] = :user_created_invited_to_team
-            end
+            result[:status] = if result[:status] == :user_exists && !user.confirmed?
+                                :user_exists_unconfirmed_invited_to_team
+                              elsif result[:status] == :user_exists
+                                :user_exists_invited_to_team
+                              else
+                                :user_created_invited_to_team
+                              end
           end
 
           result[:user_team] = user_team
@@ -196,9 +190,7 @@ module Users
         message: sanitize_input(message)
       )
 
-      if target_user.assignments_notification
-        UserNotification.create(notification: notification, user: target_user)
-      end
+      UserNotification.create(notification: notification, user: target_user) if target_user.assignments_notification
     end
 
     def check_captcha_for_invite
@@ -212,13 +204,14 @@ module Users
 
     def check_invite_users_permission
       @user = current_user
-      @emails = params[:emails].map(&:downcase)
+      @emails = params[:emails]&.map(&:downcase)
       @team = Team.find_by_id(params['teamId'])
       @role = params['role']
 
-      render_403 if @emails && @emails.empty?
-      render_403 if @team && !can_manage_team_users?(@team)
-      render_403 if @role && !UserTeam.roles.keys.include?(@role)
+      render_403 unless @emails && @team && @role
+      render_403 if @emails.empty?
+      render_403 unless can_manage_team_users?(@team)
+      render_403 unless UserTeam.roles.key?(@role)
     end
   end
 end

--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -62,14 +62,15 @@ module Users
       @invite_results = []
       @too_many_emails = false
 
-      @emails.each_with_index do |email, count|
-        if (count + 1) > Constants::INVITE_USERS_LIMIT
+      @emails.each_with_index do |email, email_counter|
+        # email_counter starts with 0
+        if email_counter >= Constants::INVITE_USERS_LIMIT
           @too_many_emails = true
           break
         end
 
         result = { email: email }
-        unless Constants::BASIC_EMAIL_REGEX === email
+        unless Constants::BASIC_EMAIL_REGEX.match?(email)
           result[:status] = :user_invalid
           @invite_results << result
           next
@@ -203,10 +204,10 @@ module Users
       @team = Team.find_by_id(params['teamId'])
       @role = params['role']
 
-      render_403 unless @emails && @team && @role
-      render_403 if @emails.empty?
-      render_403 unless can_manage_team_users?(@team)
-      render_403 unless UserTeam.roles.key?(@role)
+      return render_403 unless @emails && @team && @role
+      return render_403 if @emails.empty?
+      return render_403 unless can_manage_team_users?(@team)
+      return render_403 unless UserTeam.roles.key?(@role)
     end
   end
 end

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -908,7 +908,7 @@ class Constants
   IMPORT_REPOSITORY_ITEMS_LIMIT = 2000
 
   # Very basic regex to check for validity of emails
-  BASIC_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+  BASIC_EMAIL_REGEX = URI::MailTo::EMAIL_REGEXP
 
   TINY_MCE_ASSET_REGEX = /data-mce-token="(\w+)"/
 

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -908,7 +908,7 @@ class Constants
   IMPORT_REPOSITORY_ITEMS_LIMIT = 2000
 
   # Very basic regex to check for validity of emails
-  BASIC_EMAIL_REGEX = URI::MailTo::EMAIL_REGEXP
+  BASIC_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
 
   TINY_MCE_ASSET_REGEX = /data-mce-token="(\w+)"/
 


### PR DESCRIPTION
Jira ticket: [SCI-2840](https://biosistemika.atlassian.net/browse/SCI-2840)

### What was done
```Users::InvitationsController#invite_users (insufficient check for null parameters in #check_invite_users_permission)```
Here i found issue that if `params[:emails]` is `nil` it will fail. So i changed logic for checking `params`.

```Users::InvitationsController#invite_users (poor handling of case when user with such email already exists)```
Here i can't reproduce error, so a little bit optimize logic.

```MyModuleTagsController#create, ParameterMissing: param is missing or the value is empty: my_module_tag```
Added new check for params exist and JS code for error handling.

```my_module_tags_controller.rb #destroy```
Added new check, that tag exist, before destroy.

```
step_comments_controller.rb #load_vars
steps_controller.rb #load_vars
```
Same issue, if step `nil` it will fail.

``` tiny_mce_helper #parse_tiny_mce_asset_to_token```
We don't use it anymore.

``` assets_controller.rb #append_wd_params ```
Better use `.to_query` to converting hash to URL params.

### ToDo
One more issue in Addons
