### PR TITLE
Add a startup check for WOPI_ENABLED == true variables

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -390,7 +390,7 @@ class Asset < ApplicationRecord
     action = get_action(file_ext, action)
     if !action.nil?
       action_url = action.urlsrc
-      if ENV['WOPI_BUSINESS_USERS'] && ENV['WOPI_BUSINESS_USERS']=='true'
+      if ENV['WOPI_BUSINESS_USERS'] && ENV['WOPI_BUSINESS_USERS'] == 'true'
         action_url = action_url.gsub(/<IsLicensedUser=BUSINESS_USER&>/,
                                      'IsLicensedUser=1&')
         action_url = action_url.gsub(/<IsLicensedUser=BUSINESS_USER>/,

--- a/config/initializers/wopi_startup_check.rb
+++ b/config/initializers/wopi_startup_check.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# Only check if connection works when server starts, and if WOPI is
+# enabled
+if defined? Rails::Server && ENV['WOPI_ENABLED'] == 'true'
+  missing_vars = []
+  %w(
+    WOPI_TEST_ENABLED WOPI_DISCOVERY_URL WOPI_ENDPOINT_URL USER_SUBDOMAIN
+    WOPI_SUBDOMAIN WOPI_USER_HOST
+  ).each do |var_name|
+    missing_vars << var_name if ENV[var_name].blank?
+  end
+
+  unless missing_vars.empty?
+    puts "WARNING: Due to WOPI_ENABLED == 'true', " \
+         "following env. variables MUST also be specified: " \
+         "#{missing_vars.join(', ')}; " \
+         "aborting."
+    abort
+  end
+end

--- a/config/initializers/wopi_startup_check.rb
+++ b/config/initializers/wopi_startup_check.rb
@@ -2,7 +2,7 @@
 
 # Only check if connection works when server starts, and if WOPI is
 # enabled
-if defined? Rails::Server && ENV['WOPI_ENABLED'] == 'true'
+if defined?(Rails::Server).present? && ENV['WOPI_ENABLED'] == 'true'
   missing_vars = []
   %w(
     WOPI_TEST_ENABLED WOPI_DISCOVERY_URL WOPI_ENDPOINT_URL USER_SUBDOMAIN


### PR DESCRIPTION
Jira ticket: _n/a_

### What was done
If env. variable `WOPI_ENABLED == 'true'`, but other `WOPI` variables (with the exception of `WOPI_BUSINESS_USERS`, which defaults to `false`) are not properly defined, SciNote can start behaving very oddly, failing on all `PUT` and `PATCH` requests (while being quite hard to debug). I've simply added a new `initializer` that checks if these variables are correctly defined on server startup.

### Note:
I believe I've checked our production servers, and they all have all these env. variables defined, so this should not cause any problems upon the release.