### PR TITLE
Add delay job for handling unknown tinyMCE images

### DIFF
--- a/app/models/concerns/tiny_mce_images.rb
+++ b/app/models/concerns/tiny_mce_images.rb
@@ -80,15 +80,7 @@ module TinyMceImages
     end
 
     def copy_unknown_tiny_mce_images
-      asset_team_id = case self.class.name
-                      when 'Protocol'
-                        team_id
-                      when 'Step' || 'MyModule'
-                        protocol.team_id
-                      when 'ResultText'
-                        result.my_module.protocol.team_id
-                      end
-
+      asset_team_id = Team.find_by_object(self)
       return unless asset_team_id
 
       object_field = Extends::RICH_TEXT_FIELD_MAPPINGS[self.class.name]

--- a/app/models/concerns/tiny_mce_images.rb
+++ b/app/models/concerns/tiny_mce_images.rb
@@ -79,6 +79,49 @@ module TinyMceImages
       target.reassign_tiny_mce_image_references(cloned_img_ids)
     end
 
+    def copy_unknown_tiny_mce_images
+      asset_team_id = case self.class.name
+                      when 'Protocol'
+                        team_id
+                      when 'Step' || 'MyModule'
+                        protocol.team_id
+                      when 'ResultText'
+                        result.my_module.protocol.team_id
+                      end
+
+      return unless asset_team_id
+
+      object_field = Extends::RICH_TEXT_FIELD_MAPPINGS[self.class.name]
+
+      image_changed = false
+      parsed_description = Nokogiri::HTML(read_attribute(object_field))
+      parsed_description.css('img').each do |image|
+        if image['data-mce-token']
+          asset = TinyMceAsset.find_by_id(Base62.decode(image['data-mce-token']))
+
+          next if asset && asset.object == self
+
+          new_image = asset.image
+        else
+          new_image = URI.parse(image['src'])
+        end
+
+        new_asset = TinyMceAsset.create(
+          image: new_image,
+          object: self,
+          team_id: asset_team_id
+        )
+
+        image['src'] = ''
+        image['class'] = 'img-responsive'
+        image['data-mce-token'] = Base62.encode(new_asset.id)
+        image_changed = true
+      end
+      update(object_field => parsed_description.css('body').inner_html.to_s) if image_changed
+    rescue StandardError => e
+      Rails.logger.error "Object: #{self.class.name}, id: #{id}, error: #{e.message}"
+    end
+
     private
 
     def clean_tiny_mce_image_urls

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -324,6 +324,17 @@ class Team < ApplicationRecord
     query.select(:id, :name).map { |i| { id: i[:id], name: ApplicationController.helpers.escape_input(i[:name]) } }
   end
 
+  def self.find_by_object(obj)
+    case obj.class.name
+    when 'Protocol'
+      obj.team_id
+    when 'MyModule', 'Step'
+      obj.protocol.team_id
+    when 'ResultText'
+      obj.result.my_module.protocol.team_id
+    end
+  end
+
   private
 
   def generate_template_project

--- a/app/models/tiny_mce_asset.rb
+++ b/app/models/tiny_mce_asset.rb
@@ -41,9 +41,11 @@ class TinyMceAsset < ApplicationRecord
     end
     images.each do |image|
       image_to_update = find_by_id(Base62.decode(image))
-      image_to_update&.update(object: object, saved: true)
+      image_to_update&.update(object: object, saved: true) unless image_to_update.object
     end
     where(id: images_to_delete).destroy_all
+
+    object.delay(queue: :assets).copy_unknown_tiny_mce_images
   rescue StandardError => e
     Rails.logger.error e.message
   end


### PR DESCRIPTION
### What was done
This job cover 2 scenarios:

1) User copy image from one tinyMCE field to another. Job check if image not link to object, than we copy original image and rewrite token.

2) User copy image from other website. Job check if image don't have token, than it try copy image to S3 and create new asset.

