### PR TITLE
Add type column to zip_exports for STI [SCI-3368]

### DIFF
--- a/app/models/team_zip_export.rb
+++ b/app/models/team_zip_export.rb
@@ -7,21 +7,6 @@ require 'csv'
 class TeamZipExport < ZipExport
   include StringUtility
 
-  # Override path only for S3
-  if ENV['PAPERCLIP_STORAGE'] == 's3'
-    s3_path =
-      if ENV['S3_SUBFOLDER']
-        "/#{ENV['S3_SUBFOLDER']}/zip_exports/:attachment/"\
-        ":id_partition/:hash/:style/:filename"
-      else
-        '/zip_exports/:attachment/:id_partition/:hash/:style/:filename'
-      end
-
-    has_attached_file :zip_file, path: s3_path
-    validates_attachment :zip_file,
-                         content_type: { content_type: 'application/zip' }
-  end
-
   def generate_exportable_zip(user, data, type, options = {})
     @user = user
     zip_input_dir = FileUtils.mkdir_p(

--- a/app/models/zip_export.rb
+++ b/app/models/zip_export.rb
@@ -20,7 +20,22 @@ require 'csv'
 
 class ZipExport < ApplicationRecord
   belongs_to :user, optional: true
-  has_attached_file :zip_file
+
+  # Override path only for S3
+  if ENV['PAPERCLIP_STORAGE'] == 's3'
+    s3_path =
+      if ENV['S3_SUBFOLDER']
+        "/#{ENV['S3_SUBFOLDER']}/zip_exports/:attachment/"\
+        ":id_partition/:hash/:style/:filename"
+      else
+        '/zip_exports/:attachment/:id_partition/:hash/:style/:filename'
+      end
+
+    has_attached_file :zip_file, path: s3_path
+  else
+    has_attached_file :zip_file
+  end
+
   validates_attachment :zip_file,
                        content_type: { content_type: 'application/zip' }
 

--- a/db/migrate/20190520135317_add_type_to_zip_exports.rb
+++ b/db/migrate/20190520135317_add_type_to_zip_exports.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTypeToZipExports < ActiveRecord::Migration[5.1]
   def change
     add_column :zip_exports, :type, :string

--- a/db/migrate/20190520135317_add_type_to_zip_exports.rb
+++ b/db/migrate/20190520135317_add_type_to_zip_exports.rb
@@ -1,0 +1,5 @@
+class AddTypeToZipExports < ActiveRecord::Migration[5.1]
+  def change
+    add_column :zip_exports, :type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190424113216) do
+ActiveRecord::Schema.define(version: 20190520135317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -926,6 +926,7 @@ ActiveRecord::Schema.define(version: 20190424113216) do
     t.string "zip_file_content_type"
     t.integer "zip_file_file_size"
     t.datetime "zip_file_updated_at"
+    t.string "type"
     t.index ["user_id"], name: "index_zip_exports_on_user_id"
   end
 
@@ -1070,7 +1071,7 @@ ActiveRecord::Schema.define(version: 20190424113216) do
   add_foreign_key "wopi_apps", "wopi_discoveries"
   add_foreign_key "zip_exports", "users"
 
-  create_view "datatables_teams",  sql_definition: <<-SQL
+  create_view "datatables_teams", sql_definition: <<-SQL
       SELECT teams.id,
       teams.name,
       user_teams.role,
@@ -1086,5 +1087,4 @@ ActiveRecord::Schema.define(version: 20190424113216) do
      FROM (teams
        JOIN user_teams ON ((teams.id = user_teams.team_id)));
   SQL
-
 end


### PR DESCRIPTION
Jira ticket: [SCI-3368](https://biosistemika.atlassian.net/browse/SCI-3368)

### What was done
Added type column for proper functioning of STI. It is needed because paperclip uses class name for hash generation, so we need to know correct class name of exported zip for proper url generation.
