### PR TITLE
Fix the user.activities association so it works [SCI-3494]

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,7 +72,7 @@ class User < ApplicationRecord
   has_many :user_my_modules, inverse_of: :user
   has_many :my_modules, through: :user_my_modules
   has_many :comments, inverse_of: :user
-  has_many :activities, inverse_of: :owner
+  has_many :activities, inverse_of: :owner, foreign_key: 'owner_id'
   has_many :results, inverse_of: :user
   has_many :samples, inverse_of: :user
   has_many :samples_tables, inverse_of: :user, dependent: :destroy


### PR DESCRIPTION
Jira ticket: [SCI-3494](https://biosistemika.atlassian.net/browse/SCI-3494)

### What was done
If you call `user.activities` anywhere from inside codebase, the association didn't work (due to `user_id` on `activity.rb` being renamed to `owner_id`. This fix fixes that.

### Notes
_This PR should be merged alongside [billing!82](https://gitlab.com/biosistemika/scinote/addons/billing/merge_requests/82)._