### PR TITLE
Rename permision_eval - permission_eval [SCI-2991]

### DIFF
--- a/app/services/smart_annotations/permission_eval.rb
+++ b/app/services/smart_annotations/permission_eval.rb
@@ -6,7 +6,7 @@ module SmartAnnotations
       include Canaid::Helpers::PermissionsHelper
 
       def check(user, team, type, object)
-        send("validate_#{type}_permissions", user, team, object)
+        __send__("validate_#{type}_permissions", user, team, object)
       end
 
       private

--- a/app/services/smart_annotations/tag_to_html.rb
+++ b/app/services/smart_annotations/tag_to_html.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'smart_annotations/permision_eval'
-require 'smart_annotations/html_preview'
-
 module SmartAnnotations
   class TagToHtml
     attr_reader :html

--- a/app/services/smart_annotations/tag_to_text.rb
+++ b/app/services/smart_annotations/tag_to_text.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-require 'smart_annotations/permision_eval'
-require 'smart_annotations/text_preview'
-
 module SmartAnnotations
   class TagToText
     attr_reader :text

--- a/spec/services/smart_annotations/permission_eval_spec.rb
+++ b/spec/services/smart_annotations/permission_eval_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'smart_annotations/permision_eval'
 
 describe SmartAnnotations::PermissionEval do
   let(:subject) { described_class }


### PR DESCRIPTION
Jira ticket: [SCI-2991](https://biosistemika.atlassian.net/browse/SCI-2991)

### What was done
Hopefully this will help with getting rid of all the errors that we've been receiving for `PermissionEval`. 

Due to the file being wrongly named (file was named `permision_eval`, while the class name was `PermissionEval`), Rails autoloading didn't work, and resort was to use `require`, which was messing with autoloading in development environment after files were being altered.

Bug fix was courtesy of @mlorb for finding out the spelling mistake :slightly_smiling_face:.