### PR TITLE
Change import protocol service to build protocol service [SCI-3544]

### DIFF
--- a/app/services/protocol_importers/build_protocol_from_client_service.rb
+++ b/app/services/protocol_importers/build_protocol_from_client_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-module Protocols
+module ProtocolImporters
   class BuildProtocolFromClientService
     extend Service
 
@@ -19,7 +19,7 @@ module Protocols
 
       # TODO: check for errors
       api_response = api_client.single_protocol(id: @id)
-      normalized_hash = normalizer.load_protocol(api_response)
+      normalized_hash = normalizer.load_protocol(api_response.parsed_response)
 
       pio = ProtocolImporters::ProtocolIntermediateObject.new(normalized_json: normalized_hash,
                                                               user: @user,

--- a/app/services/protocol_importers/build_protocol_from_client_service.rb
+++ b/app/services/protocol_importers/build_protocol_from_client_service.rb
@@ -24,10 +24,8 @@ module ProtocolImporters
       pio = ProtocolImporters::ProtocolIntermediateObject.new(normalized_json: normalized_hash,
                                                               user: @user,
                                                               team: @team)
-      @pio_protocol = pio.build
-      unless @pio_protocol.valid?
-        @errors[:protocol] = pio.protocol.errors
-      end
+
+      @errors[:protocol] = pio.protocol.errors unless @pio_protocol.valid?
     rescue StandardError => e
       @errors[:build_protocol] = e.message
     ensure

--- a/app/services/protocol_importers/build_protocol_from_client_service.rb
+++ b/app/services/protocol_importers/build_protocol_from_client_service.rb
@@ -18,17 +18,18 @@ module ProtocolImporters
       return self unless valid?
 
       # TODO: check for errors
-      api_response = api_client.single_protocol(id: @id)
-      normalized_hash = normalizer.load_protocol(api_response.parsed_response)
+      api_response = api_client.single_protocol(@id)
+      normalized_hash = normalizer.normalize_protocol(api_response)
 
       pio = ProtocolImporters::ProtocolIntermediateObject.new(normalized_json: normalized_hash,
                                                               user: @user,
                                                               team: @team)
 
+      @pio_protocol = pio.build
       @errors[:protocol] = pio.protocol.errors unless @pio_protocol.valid?
+      self
     rescue StandardError => e
       @errors[:build_protocol] = e.message
-    ensure
       self
     end
 

--- a/app/utilities/protocol_importers/protocol_normalizer.rb
+++ b/app/utilities/protocol_importers/protocol_normalizer.rb
@@ -2,11 +2,11 @@
 
 module ProtocolImporters
   class ProtocolNormalizer
-    def normalize_all_protocols(client_data)
+    def normalize_all_protocols(_client_data)
       raise NotImplementedError
     end
 
-    def normalize_protocol(client_data)
+    def normalize_protocol(_client_data)
       raise NotImplementedError
     end
   end

--- a/app/utilities/protocol_importers/protocol_normalizer.rb
+++ b/app/utilities/protocol_importers/protocol_normalizer.rb
@@ -2,11 +2,11 @@
 
 module ProtocolImporters
   class ProtocolNormalizer
-    def load_all_protocols(api_response)
+    def normalize_all_protocols(client_data)
       raise NotImplementedError
     end
 
-    def load_protocol(api_response)
+    def normalize_protocol(client_data)
       raise NotImplementedError
     end
   end

--- a/app/utilities/protocol_importers/protocol_normalizer.rb
+++ b/app/utilities/protocol_importers/protocol_normalizer.rb
@@ -2,11 +2,11 @@
 
 module ProtocolImporters
   class ProtocolNormalizer
-    def load_all_protocols(_params: {})
+    def load_all_protocols(api_response)
       raise NotImplementedError
     end
 
-    def load_protocol(_id:, _params: {})
+    def load_protocol(api_response)
       raise NotImplementedError
     end
   end

--- a/app/utilities/protocol_importers/protocols_io/v3/protocol_normalizer.rb
+++ b/app/utilities/protocol_importers/protocols_io/v3/protocol_normalizer.rb
@@ -4,17 +4,12 @@ module ProtocolImporters
   module ProtocolsIO
     module V3
       class ProtocolNormalizer < ProtocolImporters::ProtocolNormalizer
-        def load_protocol(api_response)
-          normalize(api_response)
-        end
-
-        private
-
-        def normalize(response)
-          protocol_hash = response.parsed_response.with_indifferent_access[:protocol]
+        def normalize_protocol(client_data)
+          # client_data is HttpParty ApiReponse object
+          protocol_hash = client_data.parsed_response.with_indifferent_access[:protocol]
 
           normalized_data = {
-            uri: response.request.last_uri.to_s,
+            uri: client_data.request.last_uri.to_s,
             source: Constants::PROTOCOLS_IO_V3_API[:source_id],
             doi: protocol_hash[:doi],
             published_on: protocol_hash[:published_on],

--- a/app/utilities/protocol_importers/protocols_io/v3/protocol_normalizer.rb
+++ b/app/utilities/protocol_importers/protocols_io/v3/protocol_normalizer.rb
@@ -4,11 +4,8 @@ module ProtocolImporters
   module ProtocolsIO
     module V3
       class ProtocolNormalizer < ProtocolImporters::ProtocolNormalizer
-        def load_protocol(id:)
-          response = ProtocolImporters::ProtocolsIO::V3::ApiClient.new.single_protocol(id)
-
-          normalized_hash = normalize(response)
-          normalized_hash
+        def load_protocol(api_response)
+          normalize(api_response)
         end
 
         private

--- a/spec/services/protocol_importers/build_protocol_from_client_service_spec.rb
+++ b/spec/services/protocol_importers/build_protocol_from_client_service_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-describe Protocols::BuildProtocolFromClientService do
+describe ProtocolImporters::BuildProtocolFromClientService do
   let(:user) { create :user }
   let(:team) { create :team }
   let(:service_call) do
-    Protocols::BuildProtocolFromClientService
+    ProtocolImporters::BuildProtocolFromClientService
       .call(protocol_client_id: 'id', protocol_source: 'protocolsio/v3', user_id: user.id, team_id: team.id)
   end
   let(:normalized_response) do
@@ -25,7 +25,7 @@ describe Protocols::BuildProtocolFromClientService do
   context 'when have valid arguments' do
     before do
       allow_any_instance_of(ProtocolImporters::ProtocolsIO::V3::ProtocolNormalizer)
-        .to(receive(:load_protocol).and_return(normalized_response))
+        .to(receive(:normalize_protocol).and_return(normalized_response))
       # Do not generate and request real images
       allow(ProtocolImporters::AttachmentsBuilder).to(receive(:generate).and_return([]))
     end

--- a/spec/services/protocol_importers/build_protocol_from_client_service_spec.rb
+++ b/spec/services/protocol_importers/build_protocol_from_client_service_spec.rb
@@ -2,11 +2,11 @@
 
 require 'rails_helper'
 
-describe Protocols::ImportProtocolFromClientService do
+describe Protocols::BuildProtocolFromClientService do
   let(:user) { create :user }
   let(:team) { create :team }
   let(:service_call) do
-    Protocols::ImportProtocolFromClientService
+    Protocols::BuildProtocolFromClientService
       .call(protocol_client_id: 'id', protocol_source: 'protocolsio/v3', user_id: user.id, team_id: team.id)
   end
   let(:normalized_response) do
@@ -28,9 +28,6 @@ describe Protocols::ImportProtocolFromClientService do
         .to(receive(:load_protocol).and_return(normalized_response))
       # Do not generate and request real images
       allow(ProtocolImporters::AttachmentsBuilder).to(receive(:generate).and_return([]))
-    end
-    it 'Adds Protocol record' do
-      expect { service_call }.to(change { Protocol.all.count }.by(1))
     end
     # more tests will be implemented when add error handling to service
   end

--- a/spec/services/protocol_importers/build_protocol_from_client_service_spec.rb
+++ b/spec/services/protocol_importers/build_protocol_from_client_service_spec.rb
@@ -24,10 +24,22 @@ describe ProtocolImporters::BuildProtocolFromClientService do
 
   context 'when have valid arguments' do
     before do
+      client_data = double('api_response')
+
+      allow_any_instance_of(ProtocolImporters::ProtocolsIO::V3::ApiClient)
+        .to(receive(:single_protocol)
+        .and_return(client_data))
+
       allow_any_instance_of(ProtocolImporters::ProtocolsIO::V3::ProtocolNormalizer)
-        .to(receive(:normalize_protocol).and_return(normalized_response))
+        .to(receive(:normalize_protocol).with(client_data)
+        .and_return(normalized_response))
+
       # Do not generate and request real images
       allow(ProtocolImporters::AttachmentsBuilder).to(receive(:generate).and_return([]))
+    end
+
+    it 'returns ProtocolIntermediateObject' do
+      expect(service_call.pio_protocol).to be_instance_of(Protocol)
     end
     # more tests will be implemented when add error handling to service
   end

--- a/spec/utilities/protocol_importers/protocol_normalizer_spec.rb
+++ b/spec/utilities/protocol_importers/protocol_normalizer_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 describe ProtocolImporters::ProtocolNormalizer do
-  describe '.load_all_protocols' do
-    it { expect { subject.load_all_protocols({}) }.to raise_error(NotImplementedError) }
+  describe '.normalize_all_protocols' do
+    it { expect { subject.normalize_all_protocols({}) }.to raise_error(NotImplementedError) }
   end
 
-  describe '.load_protocol' do
-    it { expect { subject.load_protocol({}) }.to raise_error(NotImplementedError) }
+  describe '.normalize_protocols' do
+    it { expect { subject.normalize_protocol({}) }.to raise_error(NotImplementedError) }
   end
 end

--- a/spec/utilities/protocol_importers/protocol_normalizer_spec.rb
+++ b/spec/utilities/protocol_importers/protocol_normalizer_spec.rb
@@ -4,12 +4,10 @@ require 'rails_helper'
 
 describe ProtocolImporters::ProtocolNormalizer do
   describe '.load_all_protocols' do
-    it { expect { subject.load_all_protocols }.to raise_error(NotImplementedError) }
-    it { expect { subject.load_all_protocols(_params: 'some-params') }.to raise_error(NotImplementedError) }
+    it { expect { subject.load_all_protocols({}) }.to raise_error(NotImplementedError) }
   end
 
   describe '.load_protocol' do
-    it { expect { subject.load_protocol(_id: 'random-id') }.to raise_error(NotImplementedError) }
-    it { expect { subject.load_protocol(_id: 'random-id', _params: 'someparams') }.to raise_error(NotImplementedError) }
+    it { expect { subject.load_protocol({}) }.to raise_error(NotImplementedError) }
   end
 end

--- a/spec/utilities/protocol_importers/protocols_io/v3/protocol_normalizer_spec.rb
+++ b/spec/utilities/protocol_importers/protocols_io/v3/protocol_normalizer_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 describe ProtocolImporters::ProtocolsIO::V3::ProtocolNormalizer do
+  let(:client_data) { double('api_response') }
+
   let(:response) do
     JSON.parse(file_fixture('protocol_importers/protocols_io/v3/single_protocol.json').read)
         .to_h.with_indifferent_access
@@ -19,28 +21,27 @@ describe ProtocolImporters::ProtocolsIO::V3::ProtocolNormalizer do
         .to_h.with_indifferent_access
   end
 
-  describe '#load_protocol' do
+  describe '#normalize_protocol' do
     before do
-      allow_any_instance_of(ProtocolImporters::ProtocolsIO::V3::ApiClient)
-        .to(receive_message_chain(:single_protocol, :request, :last_uri, :to_s)
-              .and_return('https://www.protocols.io/api/v3/protocols/9451'))
+      allow(client_data).to(receive_message_chain(:request, :last_uri, :to_s)
+                        .and_return('https://www.protocols.io/api/v3/protocols/9451'))
     end
 
     context 'when have all data' do
       it 'should normalize data correctly' do
-        allow_any_instance_of(ProtocolImporters::ProtocolsIO::V3::ApiClient)
-          .to receive_message_chain(:single_protocol, :parsed_response).and_return(response)
+        allow(client_data).to receive_message_chain(:parsed_response)
+                          .and_return(response)
 
-        expect(subject.load_protocol(response).deep_stringify_keys).to be == normalized_result
+        expect(subject.normalize_protocol(client_data).deep_stringify_keys).to be == normalized_result
       end
     end
 
     context 'when do not have name' do
       it 'sets nil for name' do
-        allow_any_instance_of(ProtocolImporters::ProtocolsIO::V3::ApiClient)
-          .to receive_message_chain(:single_protocol, :parsed_response).and_return(response_without_title)
+        allow(client_data).to receive_message_chain(:parsed_response)
+                          .and_return(response_without_title)
 
-        expect(subject.load_protocol(response)[:protocol][:name]).to be_nil
+        expect(subject.normalize_protocol(client_data)[:protocol][:name]).to be_nil
       end
     end
   end

--- a/spec/utilities/protocol_importers/protocols_io/v3/protocol_normalizer_spec.rb
+++ b/spec/utilities/protocol_importers/protocols_io/v3/protocol_normalizer_spec.rb
@@ -30,7 +30,7 @@ describe ProtocolImporters::ProtocolsIO::V3::ProtocolNormalizer do
     context 'when have all data' do
       it 'should normalize data correctly' do
         allow(client_data).to receive_message_chain(:parsed_response)
-                          .and_return(response)
+          .and_return(response)
 
         expect(subject.normalize_protocol(client_data).deep_stringify_keys).to be == normalized_result
       end
@@ -39,7 +39,7 @@ describe ProtocolImporters::ProtocolsIO::V3::ProtocolNormalizer do
     context 'when do not have name' do
       it 'sets nil for name' do
         allow(client_data).to receive_message_chain(:parsed_response)
-                          .and_return(response_without_title)
+          .and_return(response_without_title)
 
         expect(subject.normalize_protocol(client_data)[:protocol][:name]).to be_nil
       end

--- a/spec/utilities/protocol_importers/protocols_io/v3/protocol_normalizer_spec.rb
+++ b/spec/utilities/protocol_importers/protocols_io/v3/protocol_normalizer_spec.rb
@@ -31,7 +31,7 @@ describe ProtocolImporters::ProtocolsIO::V3::ProtocolNormalizer do
         allow_any_instance_of(ProtocolImporters::ProtocolsIO::V3::ApiClient)
           .to receive_message_chain(:single_protocol, :parsed_response).and_return(response)
 
-        expect(subject.load_protocol(id: 'id').deep_stringify_keys).to be == normalized_result
+        expect(subject.load_protocol(response).deep_stringify_keys).to be == normalized_result
       end
     end
 
@@ -40,7 +40,7 @@ describe ProtocolImporters::ProtocolsIO::V3::ProtocolNormalizer do
         allow_any_instance_of(ProtocolImporters::ProtocolsIO::V3::ApiClient)
           .to receive_message_chain(:single_protocol, :parsed_response).and_return(response_without_title)
 
-        expect(subject.load_protocol(id: 'id')[:protocol][:name]).to be_nil
+        expect(subject.load_protocol(response)[:protocol][:name]).to be_nil
       end
     end
   end


### PR DESCRIPTION
Jira ticket: [SCI-3544](https://biosistemika.atlassian.net/browse/SCI-3544)

### What was done
Change import protocol service to build protocol service and decouple
`API client` from `Normalizer`.

#### ToDo:
With this change `ApiClient`-s should inherit from the Base protocol
importer as [done here](https://github.com/biosistemika/scinote-web/pull/1795).