### PR TITLE
Rename default libreoffice to soffice binary

### DIFF
--- a/lib/paperclip_processors/custom_file_preview.rb
+++ b/lib/paperclip_processors/custom_file_preview.rb
@@ -3,7 +3,7 @@
 module Paperclip
   class CustomFilePreview < Processor
     def make
-      libreoffice_path = ENV['LIBREOFFICE_PATH'] || 'libreoffice'
+      libreoffice_path = ENV['LIBREOFFICE_PATH'] || 'soffice'
       directory = File.dirname(@file.path)
       basename  = File.basename(@file.path, '.*')
       original_preview_file = File.join(directory, "#{basename}.png")


### PR DESCRIPTION
### What was done
Fix deploy of libreoffice to heroku-18 stack

[Buildpack PR](https://github.com/biosistemika/heroku-buildpack-mimeinfo-perl/pull/3)


### Note:
We should also fork [this repository](https://github.com/BlueTeaLondon/heroku-buildpack-libreoffice-for-heroku-18) and add it to respective instances