### PR TITLE
PDF thumbnail generation is not done by ImageMagick [SCI-3579]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
   postgresql-client \
   default-jre-headless \
   unison \
+  ghostscript \
   sudo graphviz --no-install-recommends \
   libfile-mimeinfo-perl && \
   apt-get install -y --no-install-recommends -t $(cat /tmp/lsb_release)-backports libreoffice && \

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -17,6 +17,7 @@ RUN curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
   postgresql-client \
   netcat \
   default-jre-headless \
+  ghostscript \
   sudo graphviz --no-install-recommends \
   libfile-mimeinfo-perl && \
   apt-get install -y --no-install-recommends -t stretch-backports libreoffice && \

--- a/lib/paperclip_processors/custom_file_preview.rb
+++ b/lib/paperclip_processors/custom_file_preview.rb
@@ -10,16 +10,26 @@ module Paperclip
       dst = TempfileFactory.new.generate("#{basename}.#{options[:format]}")
 
       begin
-        Paperclip.run(
-          libreoffice_path,
-          "--headless --invisible --convert-to png --outdir #{directory} #{@file.path}"
-        )
+        if @file.content_type == 'application/pdf'
+          # We use special convert options for PDFs to improve quality and
+          # background, we append [0] to convert only the first page
+          convert(
+            ":source -resize '#{options[:geometry]}' -format #{options[:format]} -flatten -quality 70 :dest",
+            source: File.expand_path(@file.path) + '[0]',
+            dest: File.expand_path(dst.path)
+          )
+        else
+          Paperclip.run(
+            libreoffice_path,
+            "--headless --invisible --convert-to png --outdir #{directory} #{@file.path}"
+          )
 
-        convert(
-          ":source -resize '#{options[:geometry]}' -format #{options[:format]} #{options[:convert_options]} :dest",
-          source: File.expand_path(original_preview_file),
-          dest: File.expand_path(dst.path)
-        )
+          convert(
+            ":source -resize '#{options[:geometry]}' -format #{options[:format]} #{options[:convert_options]} :dest",
+            source: File.expand_path(original_preview_file),
+            dest: File.expand_path(dst.path)
+          )
+        end
       ensure
         File.delete(original_preview_file) if File.file?(original_preview_file)
       end


### PR DESCRIPTION
Jira ticket: [SCI-3579](https://biosistemika.atlassian.net/browse/SCI-3579)

### What was done
Libreoffice has a bug where it cannot open a file (freezing even in GUI
mode), therefore we migrate to ImageMagick and ghostscript. On heroku
ghostscript is already included in the pack.