### PR TITLE
[SCI-3587] Endless spinner at file preview

### DIFF
--- a/app/assets/javascripts/sitewide/file_preview.js
+++ b/app/assets/javascripts/sitewide/file_preview.js
@@ -509,7 +509,7 @@ var FilePreviewModal = (function() {
           }, CHECK_READY_DELAY);
         }
       } else {
-        if (data.type === 'image') {
+        if (data.type === 'image' || (data.type === 'file' && data['preview-icon'])) {
           modal.find('.file-preview-container').empty();
           modal.find('.file-preview-container')
             .append($('<img>')

--- a/app/controllers/assets_controller.rb
+++ b/app/controllers/assets_controller.rb
@@ -76,6 +76,7 @@ class AssetsController < ApplicationController
       )
     else
       response_json['processing'] = @asset.file.processing?
+      response_json['large-preview-url'] = @asset.url(:large)
       response_json['preview-icon'] = render_to_string(
         partial: 'shared/file_preview_icon.html.erb',
         locals: { asset: @asset }


### PR DESCRIPTION
Jira ticket: [SCI-3587](https://biosistemika.atlassian.net/browse/SCI-3587)

Currently file previews were only images but in case of previewiable types, type was file.