### PR TITLE
Fix styling for StepComponents in step description [SCI-3656]

### DIFF
--- a/app/utilities/protocol_importers/protocols_io/v3/step_components.rb
+++ b/app/utilities/protocol_importers/protocols_io/v3/step_components.rb
@@ -118,9 +118,9 @@ module ProtocolImporters
             {
               type: 'reagent',
               name: desc_component[:source][:name],
+              link: desc_component[:source][:url],
               details: {
                 catalog_number: desc_component[:source][:sku],
-                link: desc_component[:source][:vendor][:link],
                 linear_formula: desc_component[:source][:linfor],
                 mol_weight: desc_component[:source][:mol_weight]
               }

--- a/app/utilities/protocol_importers/tables_builder.rb
+++ b/app/utilities/protocol_importers/tables_builder.rb
@@ -31,7 +31,7 @@ module ProtocolImporters
 
       doc = Nokogiri::HTML(description_string)
       doc.search('table').each do |t|
-        t.swap('<br/><p><i>There was a table here, it was moved to tables section.</i></p>')
+        t.swap('<br/><br/><p><i>There was a table here, it was moved to tables section.</i></p><br/><br/>')
       end
       doc.css('body').first.inner_html
     end

--- a/app/utilities/protocol_importers/tables_builder.rb
+++ b/app/utilities/protocol_importers/tables_builder.rb
@@ -15,7 +15,7 @@ module ProtocolImporters
 
         rows_nodeset.each_with_index do |row, i|
           row.css('td').each_with_index do |cell, j|
-            two_d_array[i][j] = cell.inner_html
+            two_d_array[i][j] = ActionController::Base.helpers.strip_tags(cell.inner_html)
           end
           two_d_array[i].shift if remove_first_column_row
         end

--- a/app/views/protocol_importers/templates/_command.html.erb
+++ b/app/views/protocol_importers/templates/_command.html.erb
@@ -1,5 +1,11 @@
 <p class="step-description-component-command"><b><%= t('protocol_importers.templates.command.title') %></b><br>
-  <%= "#{t('protocol_importers.templates.command.name')}: #{item[:name]}" %>
-  <%= "#{t('protocol_importers.templates.command.code')}: <code>#{item[:command]}</code>" %>
+  <% if item[:name].present? %>
+    <%= "#{t('protocol_importers.templates.command.name')}: #{item[:name]}" %> <br/>
+  <% end %>
+
+  <% if item[:command].present? %>
+    <%= t('protocol_importers.templates.command.code') %>: <br/>
+    <code> <%= item[:command] %> </code>
+<% end %>
 </p>
 <%= render partial: 'protocol_importers/templates/details', locals: { item: item } %>

--- a/app/views/protocol_importers/templates/_dataset.html.erb
+++ b/app/views/protocol_importers/templates/_dataset.html.erb
@@ -1,5 +1,9 @@
 <p class="step-description-component-dataset"><b><%= t('protocol_importers.templates.dataset.title') %></b><br>
-  <%= "#{t('protocol_importers.templates.dataset.name')}: #{item[:name]}" %>
-  <%= "#{t('protocol_importers.templates.dataset.link')}: <a href='#{item[:source]}'>#{item[:source]}</a>" if item[:source] %>
+  <% if item[:name].present? %>
+    <%= "#{t('protocol_importers.templates.dataset.name')}: #{item[:name]}" %> <br />
+  <% end %>
+  <% if item[:source].present? %>
+    <%= t('protocol_importers.templates.dataset.link') %>: <a href="<%= item[:source] %>" target="_blank"><%= item[:source] %></a>
+  <% end %>
 </p>
 <%= render partial: 'protocol_importers/templates/details', locals: { item: item } %>

--- a/app/views/protocol_importers/templates/_details.html.erb
+++ b/app/views/protocol_importers/templates/_details.html.erb
@@ -1,8 +1,9 @@
 <p>
-  <% if item[:details]&.any? %>
-    <b> <%= t('protocol_importers.templates.details.title')%>: </b>
+  <% items = item[:details]&.reject { |_,v| v.blank? } %>
+  <% if items&.any? %>
+    <i> <%= t('protocol_importers.templates.details.title')%>: </i>
     <br />
-    <% item[:details].reject { |_,v| v.blank? }.each do |k, v| %>
+    <% items.each do |k, v| %>
       <%= "#{k.humanize}: #{v.to_s}" %>
       <br />
     <% end %>

--- a/app/views/protocol_importers/templates/_gotostep.html.erb
+++ b/app/views/protocol_importers/templates/_gotostep.html.erb
@@ -1,4 +1,5 @@
 <p class="step-description-component-gotostep"><b><%= t('protocol_importers.templates.gotostep.title') %></b><br/>
   <%= "#{t('protocol_importers.templates.gotostep.number')}: #{item[:step_id]}" %><br/>
   <%= "#{t('protocol_importers.templates.gotostep.reason')}: #{item[:value]}" %><br/>
-  <%= render partial: 'protocol_importers/templates/details', locals: { item: item } %>
+</p>
+<%= render partial: 'protocol_importers/templates/details', locals: { item: item } %>

--- a/app/views/protocol_importers/templates/_note.html.erb
+++ b/app/views/protocol_importers/templates/_note.html.erb
@@ -1,4 +1,10 @@
 <p class="step-description-component-note"><b><%= t('protocol_importers.templates.note.title') %></b><br/>
-  <%= "#{t('protocol_importers.templates.note.author')}: #{item[:author]}" %><br/>
-  <%= item[:body] %></p>
+  <% if item[:author].present? %>
+    <%= "#{t('protocol_importers.templates.note.author')}: #{item[:author]}" %><br/>
+  <% end %>
+
+  <% if item[:body].present? %>
+    <%= item[:body] %>
+  <% end %>
+</p>
 <%= render partial: 'protocol_importers/templates/details', locals: { item: item } %>

--- a/app/views/protocol_importers/templates/_reagent.html.erb
+++ b/app/views/protocol_importers/templates/_reagent.html.erb
@@ -1,11 +1,11 @@
 <p class="step-description-component-reagent">
   <b><%= t('protocol_importers.templates.reagent.title') %></b>
   <br/>
-  <%= "#{t('protocol_importers.templates.reagent.name')}: #{item[:name]}" %>
-  <%  if item[:source] %>
+  <%= "#{t('protocol_importers.templates.reagent.name')}: #{item[:name]}" %> <br />
+  <%  if item[:link].present? %>
     <%= t('protocol_importers.templates.reagent.link') %>:
-    <%= "<a href='#{item[:source]}'>#{item[:source]}</a>" %>
-  <% end -%>
+    <a href="<%= item[:link] %>" target="_blank"><%= item[:link] %></a>
+  <% end %>
 </p>
 <%= render(
     partial: 'protocol_importers/templates/details',

--- a/app/views/protocol_importers/templates/_software.html.erb
+++ b/app/views/protocol_importers/templates/_software.html.erb
@@ -1,6 +1,11 @@
 <p class="step-description-component-software"><b><%= t('protocol_importers.templates.software.title') %></b><br>
-  <%= "#{t('protocol_importers.templates.software.name')}: #{item[:name]}" %>
-  <%= "#{t('protocol_importers.templates.software.link')}: #{ActionController::Base.helpers.link_to(item[:source], item[:source])}" %>
+  <% if item[:name].present? %>
+    <%= "#{t('protocol_importers.templates.software.name')}: #{item[:name]}" %>
+  <% end %>
+  <br>
+  <% if item[:source].present? %>
+    <%= t('protocol_importers.templates.software.link') %>: <a href="<%= item[:source] %>" target="_blank"><%= item[:source] %></a>
+  <% end %>
 </p>
 <%= render partial: 'protocol_importers/templates/details', locals: { item: item } %>
 

--- a/app/views/protocol_importers/templates/_warning.html.erb
+++ b/app/views/protocol_importers/templates/_warning.html.erb
@@ -1,3 +1,3 @@
-<p class="step-description-component-warning"><b><%= t('protocol_importers.templates.warning.title') %><b><br/>
+<p class="step-description-component-warning"><b><%= t('protocol_importers.templates.warning.title') %></b><br/>
 <%= item[:body] %></p>
 <%= render partial: 'protocol_importers/templates/details', locals: { item: item } %>

--- a/app/views/protocol_importers/templates/protocol_description.html.erb
+++ b/app/views/protocol_importers/templates/protocol_description.html.erb
@@ -1,8 +1,8 @@
-<% if @description[:body] %>
+<% if @description[:body].present? %>
   <p> <%= sanitize(@description[:body], tags: Constants::PROTOCOLS_DESC_TAGS) %> </p>
   <br/>
 <% end %>
-<% if @description[:image] %>
+<% if @description[:image].present? %>
   <br/>
   <img src='<%= @description[:image] %>' />
   <br/>

--- a/app/views/protocol_importers/templates/step_description.html.erb
+++ b/app/views/protocol_importers/templates/step_description.html.erb
@@ -1,4 +1,4 @@
-<% if @step_description[:body] %>
+<% if @step_description[:body].present? %>
   <p> <%= sanitize(@step_description[:body], tags: Constants::PROTOCOLS_DESC_TAGS) %> </p>
 <% end %>
 

--- a/spec/fixtures/files/protocol_importers/normalized_single_protocol.json
+++ b/spec/fixtures/files/protocol_importers/normalized_single_protocol.json
@@ -72,9 +72,9 @@
             {
               "type": "reagent",
               "name": "2 mg Gastrin I, human",
+              "link": "https://www.biorbyt.com/gastrin-i-human-orb321073",
               "details": {
                 "catalog_number": "",
-                "link": "https://www.biorbyt.com/gastrin-i-human-orb321073",
                 "linear_formula": "C130H204N38O31S",
                 "mol_weight": 0.1
               }

--- a/spec/fixtures/files/protocol_importers/protocols_io/v3/single_protocol.json
+++ b/spec/fixtures/files/protocol_importers/protocols_io/v3/single_protocol.json
@@ -486,7 +486,7 @@
               "mol_weight": 0.1,
               "name": "2 mg Gastrin I, human",
               "linfor": "C130H204N38O31S",
-              "url": "",
+              "url": "https://www.biorbyt.com/gastrin-i-human-orb321073",
               "sku": "",
               "public": 0,
               "vendor": {


### PR DESCRIPTION
Jira ticket: [SCI-3656](https://biosistemika.atlassian.net/browse/SCI-3656)

### What was done
Removed printing HTML tags with ruby.

### Note:
Link for reagent moved out of `details` section because we do not print `<a>` tags in details partial. And we are using the link inside of reagent not inside of vendor from now on. This is a relevant field in the last published protocols. 
