### PR TITLE
Improve "make run" command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ rails-production:
 	@docker-compose -f docker-compose.production.yml run --rm web $(cmd)
 
 run:
-	rm tmp/pids/server.pid || true
+	rm -f tmp/pids/server.pid
 	@docker-compose up -d
 	@docker attach scinote_web_development
 


### PR DESCRIPTION
Jira ticket: [SCI-xxxx](https://biosistemika.atlassian.net/browse/SCI-xxxx)

Using the "-f" flag on "rm" makes it exit silently and with success if the file is not here. This little change prevents the user running the command from seeing: `rm: cannot remove 'tmp/pids/server.pid': No such file or directory`.

### What was done
Use the -f flag on the `rm` command so it exits with success if the file is not present.
