### PR TITLE
Revalidate internal dimension when dragging

### DIFF
--- a/app/assets/javascripts/projects/canvas.js.erb
+++ b/app/assets/javascripts/projects/canvas.js.erb
@@ -2373,6 +2373,7 @@ function addDraggablesToInstance(elements, gridDistX, gridDistY) {
       draggedModule.removeClass("collided");
       elLeft(draggedModule, leftInitial);
       elTop(draggedModule, topInitial);
+      instance.revalidate(draggedModule);
       instance.repaintEverything();
     }
 


### PR DESCRIPTION
Close SCI-3673

Jira ticket: [SCI-3673](https://biosistemika.atlassian.net/browse/SCI-3673)

### What was done
Revalidate internal dimension if `collided` was false on element. Taken from [here](http://jsplumb.github.io/jsplumb/dragging.html).
