### PR TITLE
[SCI-3567] Add check_pending! call for test migrations

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -29,9 +29,12 @@ Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 #
 # Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
-# Checks for pending migration and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
-ActiveRecord::Migration.maintain_test_schema!
+# Checks for pending migration
+begin
+  ActiveRecord::Migration.check_pending!
+rescue ActiveRecord::PendingMigrationError => e
+  abort(e.message)
+end
 
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures


### PR DESCRIPTION
Close SCI-3567

Jira ticket: [SCI-3567](https://biosistemika.atlassian.net/browse/SCI-3567)

### What was done
When running `bundle exec rspec spec` for the very first time it will call `ActiveRecord::Migration.maintain_test_schema!` in `spec/rails_helper.rb#34` which will call `db:test:load_schema`. This will try to load the schema into the test DB but due to this commit [here](https://github.com/biosistemika/scinote-web/commit/07d658ab821202e2e2ecee197a5f6e575ff7ae7e),  it will fail since `schema.rb` does not support custom PostgreSQL functions, `trim_html_tags` in our case([docs](https://guides.rubyonrails.org/active_record_migrations.html#schema-dumping-and-you), [relevant](https://stackoverflow.com/questions/46777685/rails-test-db-constantly-losing-my-postgresql-functions)). For such use cases `structure.sql` should be used. So the command fails and it says we have pending migrations, we try to run `rails db:migrate RAILS_ENV=test` but it will fail on `CreateAssets` migrations, saying assets table already exists. `db:migrate:status` and `ActiveRecord::SchemaMigration.last.version` all pinpoint to the `CreateSteps` migration (`20150715135452`), which is one before the `CreateAssets` migration. Note that assets table contains a column with `trim_html_tags` PostgreSQL function call and I can only assume that when loading schema above, the DB gets corrupted when trying to create a column with `trim_html_tags` function but the original table still remains, which results in rails `db:migrate RAILS_ENV=test` migration failing. DB is corrupted, so the only steps to recover are:

```
rails db:environment:set RAILS_ENV=test
rake db:drop db:create db:migrate RAILS_ENV=test
```

There’s not much else I can do with this setup. 

I’ll switch to `check_pending!` [call](https://github.com/rails/rails/blob/4c8c8c87b07844b26564ca6aa2052660e601bc3d/activerecord/lib/active_record/migration.rb#L585) which will only warn us about the migrations and not corrupt DB, so the migrations will go through smoothly.

Sherlock out.
