### PR TITLE
Fix global search for inventories [SCI-3782]

### DIFF
--- a/app/controllers/repositories_controller.rb
+++ b/app/controllers/repositories_controller.rb
@@ -311,7 +311,7 @@ class RepositoriesController < ApplicationController
   def load_parent_vars
     @team = current_team
     render_404 unless @team
-    @repositories = Repository.accessible_by_teams(@team)
+    @repositories = Repository.accessible_by_teams(@team).order('repositories.created_at ASC')
   end
 
   def check_team

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -36,7 +36,6 @@ class Repository < ApplicationRecord
              'OR team_repositories.team_id IN (?) '\
              'OR repositories.shared = true', teams, teams)
       .distinct
-      .order(:created_at)
   }
 
   def self.search(


### PR DESCRIPTION
Jira ticket: [SCI-3782](https://biosistemika.atlassian.net/browse/SCI-3782)

### What was done
Fix global search for inventories.
Sometimes `.order` and `.distinct` together generate not working query. Better not use it in scope, because it can generate unpredictable errors.

