### PR TITLE
Update trim_html_tags Postgres function [SCI-3726]

### DIFF
--- a/db/migrate/20190830141257_update_trim_html_tags_function.rb
+++ b/db/migrate/20190830141257_update_trim_html_tags_function.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class UpdateTrimHtmlTagsFunction < ActiveRecord::Migration[5.2]
+  def up
+    execute(
+      "CREATE OR REPLACE FUNCTION
+        trim_html_tags(IN input TEXT, OUT output TEXT) AS $$
+      SELECT regexp_replace(input, E'<[^>]*>', '', 'g');
+      $$ LANGUAGE SQL;"
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_12_072649) do
+ActiveRecord::Schema.define(version: 2019_08_30_141257) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gist"


### PR DESCRIPTION
Jira ticket: [SCI-3726](https://biosistemika.atlassian.net/browse/SCI-3726)

### What was done
Update trim_html_tags Postgres function in order to not exclude smart annotations from global search

