### PR TITLE
Make previewable document filter more strict [SCI-3817]

### DIFF
--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -63,9 +63,11 @@ Paperclip::Attachment.class_eval do
   end
 
   def previewable_document?
-    previewable = Constants::PREVIEWABLE_FILE_TYPES.include?(content_type)
+    extensions = %w(.txt .pdf .xlsx .docx .pptx .xls .rtf .doc .ppt .odt .ods .odp)
 
-    extensions = %w(.xlsx .docx .pptx .xls .doc .ppt)
+    previewable = Constants::PREVIEWABLE_FILE_TYPES.include?(content_type) &&
+                  extensions.include?(File.extname(original_filename))
+
     # Mimetype sometimes recognizes Office files as zip files
     # In this case we also check the extension of the given file
     # Otherwise the conversion should fail if the file is being something else


### PR DESCRIPTION
Jira ticket: [SCI-3817](https://biosistemika.atlassian.net/browse/SCI-3817)

### What was done
Make previewable document filter more strict, to avoid some custom file formats we don't want preview generated for
