### PR TITLE
Fix bug on API endpoint when creating result [SCI-3819]

### DIFF
--- a/app/controllers/api/v1/results_controller.rb
+++ b/app/controllers/api/v1/results_controller.rb
@@ -45,9 +45,19 @@ module Api
       end
 
       def create_text_result
-        result_text_params[:text] = convert_old_tiny_mce_format(result_text_params[:text])
-        result_text = ResultText.new(text: result_text_params[:text])
-        result_text.transaction do
+        Result.transaction do
+          @result = Result.create!(
+            user: current_user,
+            my_module: @task,
+            name: result_params[:name],
+            last_modified_by: current_user
+          )
+
+          result_text = ResultText.create!(
+            result: @result,
+            text: convert_old_tiny_mce_format(result_text_params[:text])
+          )
+
           if tiny_mce_asset_params.present?
             tiny_mce_asset_params.each do |t|
               image_params = t[:attributes]
@@ -66,13 +76,8 @@ module Api
               )
               result_text.text.sub!("data-mce-token=\"#{token}\"", "data-mce-token=\"#{Base62.encode(tiny_image.id)}\"")
             end
+            result_text.save!
           end
-          @result = Result.new(user: current_user,
-                               my_module: @task,
-                               name: result_params[:name],
-                               result_text: result_text,
-                               last_modified_by: current_user)
-          @result.save! && result_text.save!
         end
       end
 


### PR DESCRIPTION
Jira ticket: [SCI-3819](https://biosistemika.atlassian.net/browse/SCI-3819)

### What was done
_The order of saving `Result` and `ResultText` to database was changed, because `object_id` of `TinyMceAsset` was missing before._

#### ToDo:
_Tests should be fixed in order to cover these kind of bugs. Also `step_id` and `result_text_id` should be removed from model `TinyMceAsset` (they are redundant)._

