### PR TITLE
Fix missing icon on shared inventories in global search [SCI-3847]

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -129,14 +129,13 @@ class SearchController < ApplicationController
 
         current_user.teams.includes(:repositories).each do |team|
           team_results = {}
+          team_results[:team] = team
           team_results[:count] = 0
           team_results[:repositories] = {}
           Repository.accessible_by_teams(team).each do |repository|
             repository_results = {}
             repository_results[:id] = repository.id
-            if (shared_repo = repository.team_repositories.where(team: team).take)
-              repository_results[:shared] = shared_repo[:permission_level]
-            end
+            repository_results[:repository] = repository
             repository_results[:count] = 0
             search_results.each do |result|
               if repository.id == result.id

--- a/app/helpers/inventories_helper.rb
+++ b/app/helpers/inventories_helper.rb
@@ -11,7 +11,7 @@ module InventoriesHelper
     else
       # The icon should be hiden if repo is not shared (we're updating it dinamically)
       css_classes = ["repository-share-status"]
-      css_classes.push("hidden") unless inventory.i_shared?(current_team)
+      css_classes.push("hidden") unless inventory.i_shared?(team)
       css_title = t('repositories.icon_title.i_shared')
 
       content_tag :span, title: css_title, class: css_classes.join(" ") do

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -233,11 +233,7 @@
                                search_id: @search_id}.to_query %>">
                   <span class="badge pull-right"><%= values[:count] %></span>
                   <%= repository %>
-                  <% if values[:shared] == 'write' %>
-                    <%= draw_custom_icon('shared-edit') %>
-                  <% elsif values[:shared] == 'read' %>
-                    <%= draw_custom_icon('shared-read') %>
-                  <% end %>
+                  <%= inventory_shared_status_icon(values[:repository], results[:team]) %>
                 </a>
               </li>
             <% end %>


### PR DESCRIPTION
Jira ticket: [SCI-3847](https://biosistemika.atlassian.net/browse/SCI-3847)

### Note
_These was some old code for rendering shared icons on global search (forgot during refactoring)._