### PR TITLE
Update canaid Gem reference in Gemfile to use tags, not master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,7 @@ gem 'base62' # Used for smart annotations
 gem 'newrelic_rpm'
 
 # Permission helper Gem
-gem 'canaid', git: 'https://github.com/biosistemika/canaid', branch: 'master'
+gem 'canaid', git: 'https://github.com/biosistemika/canaid', tag: '1.0.4'
 
 group :development, :test do
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/biosistemika/canaid
-  revision: 6c02dfe7e8354e130d543ec0b398ab6411892d13
-  branch: master
+  revision: c65ea0a2fae1edb368aa561e35a153c2cd3bccdd
+  tag: 1.0.4
   specs:
-    canaid (1.0.3)
-      devise (>= 3.4.1)
+    canaid (1.0.4)
+      devise (~> 4.6.2)
       docile (>= 1.1.0)
-      rails (>= 4)
+      rails (~> 5.2.3)
 
 GIT
   remote: https://github.com/biosistemika/jquery-scrollto-rails
@@ -123,7 +123,7 @@ GEM
       aws-eventstream (~> 1.0, >= 1.0.2)
     backports (3.14.0)
     base62 (1.0.0)
-    bcrypt (3.1.12)
+    bcrypt (3.1.13)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
@@ -228,7 +228,7 @@ GEM
     diff-lcs (1.3)
     discard (1.0.0)
       activerecord (>= 4.2, < 6)
-    docile (1.3.1)
+    docile (1.3.2)
     doorkeeper (5.1.0)
       railties (>= 5)
     erubi (1.8.0)
@@ -319,7 +319,7 @@ GEM
     method_source (0.9.2)
     mime-types (1.25.1)
     mimemagic (0.3.3)
-    mini_mime (1.0.1)
+    mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
     momentjs-rails (2.17.1)
@@ -334,8 +334,8 @@ GEM
       jquery-rails
       rails (>= 3.2.0)
     newrelic_rpm (6.2.0.354)
-    nio4r (2.3.1)
-    nokogiri (1.10.3)
+    nio4r (2.5.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.1)
       nokogiri (~> 1.8, >= 1.8.4)
@@ -417,7 +417,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
+    rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
     rails_12factor (0.0.3)
       rails_serve_static_assets
@@ -433,7 +433,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
-    rake (12.3.2)
+    rake (12.3.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -441,9 +441,9 @@ GEM
     recaptcha (4.14.0)
       json
     regexp_parser (1.4.0)
-    responders (2.4.1)
-      actionpack (>= 4.2.0, < 6.0)
-      railties (>= 4.2.0, < 6.0)
+    responders (3.0.0)
+      actionpack (>= 5.0)
+      railties (>= 5.0)
     rgl (0.5.4)
       lazy_priority_queue (~> 0.1.0)
       stream (~> 0.5.2)


### PR DESCRIPTION
Jira ticket: _none_

### What was done
As @okriuchykhin suggested, to have a more fine-grained control of which versions of [`canaid`](https://github.com/biosistemika/canaid) Gem we use in SciNote, I've switched to reference its Git tag. And I've also labeled current `master` on Canaid as `1.0.4` tag.