### PR TITLE
Add override for ActiveStorage downloader to handle missing file checksums [SCI-3888]

### DIFF
--- a/db/migrate/20190613134100_convert_to_active_storage.rb
+++ b/db/migrate/20190613134100_convert_to_active_storage.rb
@@ -26,6 +26,7 @@ class ConvertToActiveStorage < ActiveRecord::Migration[5.2]
     transaction do
       models.each do |model|
         next unless ActiveRecord::Base.connection.table_exists?(model.table_name)
+        next if model.name == 'TeamZipExport'
 
         attachments = model.column_names.map do |c|
           $1 if c =~ /(.+)_file_name$/


### PR DESCRIPTION
Jira ticket: [SCI-3888](https://biosistemika.atlassian.net/browse/SCI-3888)

### What was done
Added override for ActiveStorage downloader to handle missing file checksums
