### PR TITLE
Switch to Rails 6.0 app defaults with zeitwerk loader [SCI-3890]

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,9 @@ Bundler.require(*Rails.groups)
 module Scinote
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
+
+    Rails.autoloaders.main.ignore(Rails.root.join('addons', '*', 'app', 'decorators'))
 
     # config.add_autoload_paths_to_load_path = false
 


### PR DESCRIPTION
Jira ticket: [SCI-3890](https://biosistemika.atlassian.net/browse/SCI-3890)

### What was done
Switch to Rails 6.0 app defaults with zeitwerk loader

