### PR TITLE
[SCI-3751] Improve the auto-save functionality on RTF fields

### DIFF
--- a/app/assets/javascripts/protocols/steps.js.erb
+++ b/app/assets/javascripts/protocols/steps.js.erb
@@ -605,6 +605,7 @@
           toggleButtons(true);
           SmartAnnotation.preventPropagation('.atwho-user-popover');
 
+          tinyMCE.editors.step_description_textarea.plugins.autosave.removeDraft();
           tinyMCE.editors.step_description_textarea.remove();
 
           //Rerender tables

--- a/app/assets/javascripts/protocols/steps.js.erb
+++ b/app/assets/javascripts/protocols/steps.js.erb
@@ -366,6 +366,7 @@
       });
       toggleButtons(true);
       DragNDropSteps.clearFiles();
+
       tinyMCE.editors.step_description_textarea.remove();
     });
   }
@@ -604,7 +605,6 @@
           toggleButtons(true);
           SmartAnnotation.preventPropagation('.atwho-user-popover');
 
-          tinyMCE.editors.step_description_textarea.plugins.autosave.removeDraft();
           tinyMCE.editors.step_description_textarea.remove();
 
           //Rerender tables

--- a/app/assets/javascripts/sitewide/tiny_mce.js
+++ b/app/assets/javascripts/sitewide/tiny_mce.js
@@ -53,9 +53,9 @@ var TinyMCE = (function() {
       var notificationBar = $('<div class="restore-draft-notification"></div>');
 
       if (lastDraftTime < lastUpdated) {
-        notificationBar.text('Older version of the text below has been saved in the browser. Do you want to restore it?');
+        notificationBar.text(I18n.t('tiny_mce.older_version_available'));
       } else {
-        notificationBar.text('Newer version of the text below has been saved in the browser. Do you want to restore it?');
+        notificationBar.text(I18n.t('tiny_mce.newer_version_available'));
       }
 
       // Add notification bar

--- a/app/assets/javascripts/sitewide/tiny_mce.js
+++ b/app/assets/javascripts/sitewide/tiny_mce.js
@@ -89,10 +89,10 @@ var TinyMCE = (function() {
           .before('<div class="tinymce-placeholder" style="height:' + tinyMceInitSize + 'px"></div>');
         tinyMceContainer.addClass('hidden');
 
-        if (textAreaObject.data('objectType') === 'step') {
+        if (textAreaObject.data('objectType') === 'step'
+          || textAreaObject.data('objectType') === 'result_text') {
           document.location.hash = textAreaObject.data('objectType') + '_' + textAreaObject.data('objectId');
         }
-
 
         tinyMCE.init({
           cache_suffix: '?v=4.9.3', // This suffix should be changed any time library is updated

--- a/app/assets/javascripts/sitewide/tiny_mce.js
+++ b/app/assets/javascripts/sitewide/tiny_mce.js
@@ -16,7 +16,7 @@ var TinyMCE = (function() {
     });
   }
 
-  function refreshSaveButton(editor) {
+  function makeItDirty(editor) {
     var editorForm = $(editor.getContainer()).closest('form');
     editorForm.find('.tinymce-status-badge').addClass('hidden');
     $(editor.getContainer())
@@ -43,10 +43,11 @@ var TinyMCE = (function() {
     var lastUpdated = $(selector).data('last-updated');
 
     var restoreBtn = $('<button class="btn restore-draft-btn pull-right">Restore Draft</button>');
-    var cancelBtn = $('<div class="tinymce-cancel-notification-button pull-right">' +
-      '<button type="button">' +
-      '<span class="fas fa-times"></span>' +
-      '</button></div>');
+    var cancelBtn = $(`<div class="tinymce-cancel-notification-button pull-right">
+                        <button type="button">
+                          <span class="fas fa-times"></span>
+                        </button>
+                       </div>`);
 
     // Check whether we have draft stored
     if (editor.plugins.autosave.hasDraft()) {
@@ -59,13 +60,12 @@ var TinyMCE = (function() {
       }
 
       // Add notification bar
-      $(notificationBar).append(cancelBtn);
-      $(notificationBar).append(restoreBtn);
+      $(notificationBar).append(cancelBtn).append(restoreBtn);
       $(editor.contentAreaContainer).before(notificationBar);
 
       $(restoreBtn).click(function() {
         editor.plugins.autosave.restoreDraft();
-        refreshSaveButton(editor);
+        makeItDirty(editor);
         notificationBar.remove();
       });
 
@@ -287,7 +287,7 @@ var TinyMCE = (function() {
             });
 
             editor.on('Dirty', function() {
-              refreshSaveButton(editor);
+              makeItDirty(editor);
             });
 
             editor.on('remove', function() {

--- a/app/assets/javascripts/sitewide/tiny_mce.js
+++ b/app/assets/javascripts/sitewide/tiny_mce.js
@@ -16,6 +16,12 @@ var TinyMCE = (function() {
     });
   }
 
+  function refreshSaveButton(editor) {
+    var editorForm = $(editor.getContainer()).closest('form');
+    editorForm.find('.tinymce-status-badge').addClass('hidden');
+    $(editor.getContainer())
+      .find('.tinymce-save-button').removeClass('hidden');
+  }
 
 
   // Get LocalStorage auto save path
@@ -36,8 +42,8 @@ var TinyMCE = (function() {
     var lastDraftTime = parseInt(tinyMCE.util.LocalStorage.getItem(prefix + 'time'), 10);
     var lastUpdated = $(selector).data('last-updated');
 
-    var restoreBtn = $('<button type="button" class="btn pull-right">Restore Draft</button>');
-    var cancelBtn = $('<div class="tinymce-cancel-button pull-right">' +
+    var restoreBtn = $('<button class="btn restore-draft-btn pull-right">Restore Draft</button>');
+    var cancelBtn = $('<div class="tinymce-cancel-notification-button pull-right">' +
       '<button type="button">' +
       '<span class="fas fa-times"></span>' +
       '</button></div>');
@@ -60,6 +66,7 @@ var TinyMCE = (function() {
       $(restoreBtn).click(function() {
         editor.plugins.autosave.restoreDraft();
         editor.plugins.autosave.removeDraft();
+        refreshSaveButton(editor);
         notificationBar.remove();
       });
 
@@ -281,10 +288,7 @@ var TinyMCE = (function() {
             });
 
             editor.on('Dirty', function() {
-              var editorForm = $(editor.getContainer()).closest('form');
-              editorForm.find('.tinymce-status-badge').addClass('hidden');
-              $(editor.getContainer())
-                .find('.tinymce-save-button').removeClass('hidden');
+              refreshSaveButton(editor);
             });
 
             editor.on('remove', function() {

--- a/app/assets/javascripts/sitewide/tiny_mce.js
+++ b/app/assets/javascripts/sitewide/tiny_mce.js
@@ -65,7 +65,6 @@ var TinyMCE = (function() {
 
       $(restoreBtn).click(function() {
         editor.plugins.autosave.restoreDraft();
-        editor.plugins.autosave.removeDraft();
         refreshSaveButton(editor);
         notificationBar.remove();
       });

--- a/app/assets/javascripts/sitewide/tiny_mce.js
+++ b/app/assets/javascripts/sitewide/tiny_mce.js
@@ -92,7 +92,7 @@ var TinyMCE = (function() {
           cache_suffix: '?v=4.9.3', // This suffix should be changed any time library is updated
           selector: selector,
           menubar: 'file edit view insert format table',
-          toolbar: 'undo redo restoredraft | insert | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link | forecolor backcolor | customimageuploader | codesample | table tabledelete | tableprops tablerowprops tablecellprops | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol ',
+          toolbar: 'undo redo | insert | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link | forecolor backcolor | customimageuploader | codesample | table tabledelete | tableprops tablerowprops tablecellprops | tableinsertrowbefore tableinsertrowafter tabledeleterow | tableinsertcolbefore tableinsertcolafter tabledeletecol',
           plugins: 'autosave autoresize customimageuploader link advlist codesample autolink lists charmap hr anchor searchreplace wordcount visualblocks visualchars insertdatetime nonbreaking save directionality paste textcolor placeholder colorpicker textpattern table',
           autoresize_bottom_margin: 20,
           codesample_languages: [

--- a/app/assets/javascripts/tinymce/plugins/placeholder/plugin.js
+++ b/app/assets/javascripts/tinymce/plugins/placeholder/plugin.js
@@ -27,12 +27,26 @@ tinymce.PluginManager.add('placeholder', function(editor) {
   editor.on('init', function() {
     var label = new Label();
 
+    // Correct top css property due to notification bar
+    function calculatePlaceholderPosition() {
+      var editorForm = $(editor.getContainer()).closest('form');
+      var editorToolbar = editorForm.find('.mce-top-part');
+
+      var restoreDraftNotification = $(editorForm).find('.restore-draft-notification');
+      var restoreDraftHeight = restoreDraftNotification.context ? restoreDraftNotification.height() : 0;
+      var newTop = $(editorToolbar).height() + restoreDraftHeight;
+      $(label.el).css('top', newTop + 'px');
+    }
+
     function checkPlaceholder() {
+      // Show/hide depending on the content
       if (editor.getContent() === '') {
         label.show();
       } else {
         label.hide();
       }
+
+      calculatePlaceholderPosition();
     }
 
     function onKeydown() {

--- a/app/assets/stylesheets/tiny_mce.scss
+++ b/app/assets/stylesheets/tiny_mce.scss
@@ -82,9 +82,7 @@
 .restore-draft-notification {
   background: $state-info-bg !important;
   height: 25px !important;
-  padding-left: 10px !important;
-  padding-right: 10px !important;
-  padding-top: 5px !important;
+  padding: 5px 10px 0px 10px !important;
 
   .restore-draft-btn {
     border: 1px solid $color-silver-chalice;

--- a/app/assets/stylesheets/tiny_mce.scss
+++ b/app/assets/stylesheets/tiny_mce.scss
@@ -82,7 +82,7 @@
 .restore-draft-notification {
   background: $state-info-bg !important;
   height: 25px !important;
-  padding: 5px 10px 0px 10px !important;
+  padding: 5px 10px 0 !important;
 
   .restore-draft-btn {
     border: 1px solid $color-silver-chalice;

--- a/app/assets/stylesheets/tiny_mce.scss
+++ b/app/assets/stylesheets/tiny_mce.scss
@@ -67,12 +67,31 @@
   background: $color-white !important;
 }
 
+.tinymce-cancel-notification-button {
+  cursor: pointer;
+
+  .fas {
+    color: $color-silver-chalice;
+    font-family: 'Font Awesome 5 Free';
+    font-weight: 501;
+    margin-left: 10px;
+    margin-top: 4px;
+  }
+}
+
 .restore-draft-notification {
   background: $state-info-bg !important;
   height: 25px !important;
   padding-left: 10px !important;
   padding-right: 10px !important;
   padding-top: 5px !important;
+
+  .restore-draft-btn {
+    border: 1px solid $color-silver-chalice;
+    font-size: 12px;
+    margin-top: -2px;
+    padding: 3px 10px 3px 10px;
+  }
 }
 
 // scss-lint:enable ImportantRule

--- a/app/assets/stylesheets/tiny_mce.scss
+++ b/app/assets/stylesheets/tiny_mce.scss
@@ -66,4 +66,13 @@
 .mce-toolbar {
   background: $color-white !important;
 }
+
+.restore-draft-notification {
+  background: $state-info-bg !important;
+  height: 25px !important;
+  padding-left: 10px !important;
+  padding-right: 10px !important;
+  padding-top: 5px !important;
+}
+
 // scss-lint:enable ImportantRule

--- a/app/views/my_modules/_description_form.html.erb
+++ b/app/views/my_modules/_description_form.html.erb
@@ -24,6 +24,5 @@
                           object_type: 'my_module',
                           object_id: @my_module.id,
                           highlightjs_path: asset_path('highlightjs-github-theme.css'),
-                          last_updated: @my_module.updated_at.to_i * 1000
-                        } ) %>
+                          last_updated: @my_module.updated_at.to_i * 1000 } ) %>
 <% end %>

--- a/app/views/my_modules/_description_form.html.erb
+++ b/app/views/my_modules/_description_form.html.erb
@@ -23,5 +23,7 @@
                         data: {
                           object_type: 'my_module',
                           object_id: @my_module.id,
-                          highlightjs_path: asset_path('highlightjs-github-theme.css') } ) %>
+                          highlightjs_path: asset_path('highlightjs-github-theme.css'),
+                          last_updated: @my_module.updated_at.to_i * 1000
+                        } ) %>
 <% end %>

--- a/app/views/my_modules/protocols/_protocol_description_form.html.erb
+++ b/app/views/my_modules/protocols/_protocol_description_form.html.erb
@@ -23,5 +23,6 @@
                         data: {
                           object_type: 'protocol',
                           object_id: protocol.id,
-                          highlightjs_path: asset_path('highlightjs-github-theme.css') } ) %>
+                          highlightjs_path: asset_path('highlightjs-github-theme.css'),
+                          last_updated: protocol.updated_at.to_i * 1000 } ) %>
 <% end %>

--- a/app/views/result_texts/_edit.html.erb
+++ b/app/views/result_texts/_edit.html.erb
@@ -7,7 +7,8 @@
                              value: @result.result_text.tinymce_render(:text),
                              data: { object_type: 'result_text',
                                      object_id: @result.result_text.id,
-                                     highlightjs_path: asset_path('highlightjs-github-theme.css') }) %>
+                                     highlightjs_path: asset_path('highlightjs-github-theme.css'),
+                                     last_updated: @result.updated_at.to_i * 1000 }) %>
     <% end %><br />
     <div class="align-right">
       <button type="button" class="btn btn-default cancel-edit">

--- a/app/views/result_texts/_new.html.erb
+++ b/app/views/result_texts/_new.html.erb
@@ -6,7 +6,8 @@
                              id: :result_text_attributes_textarea,
                              data: { object_type: 'result_text',
                                      object_id: @result.result_text.id,
-                                     highlightjs_path: asset_path('highlightjs-github-theme.css') }) %>
+                                     highlightjs_path: asset_path('highlightjs-github-theme.css'),
+                                     last_updated: @result.updated_at.to_i * 1000 }) %>
     <% end %><br />
     <div class="align-right">
       <button type="button" class="btn btn-default cancel-new">

--- a/app/views/steps/_empty_step.html.erb
+++ b/app/views/steps/_empty_step.html.erb
@@ -36,7 +36,8 @@
                             data: {
                               object_type: 'step',
                               object_id: @step.id,
-                              highlightjs_path: asset_path('highlightjs-github-theme.css') } ) %>
+                              highlightjs_path: asset_path('highlightjs-github-theme.css'),
+                              last_updated: @step.updated_at.to_i * 1000 }) %>
     </div>
   </div>
   <div class="tab-pane" role="tabpanel" id="new-step-checklists">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2007,6 +2007,8 @@ en:
     server_not_respond: "Didn't get a response from the server"
     saved_label: "Saved"
     leaving_warning: "You have made some changes, are you sure you want to leave this page?"
+    older_version_available: "Older version of the text below has been saved in the browser. Do you want to restore it?"
+    newer_version_available: "Newer version of the text below has been saved in the browser. Do you want to restore it?"
   general:
     save: "Save"
     update: "Update"


### PR DESCRIPTION
Jira ticket: [SCI-3751](https://biosistemika.atlassian.net/browse/SCI-3751)

### What was done
Figure out where autosave plugin saves the draft and the time of the
draft. I used `updated_at` for every model to compare the time since we
do not save description field updates separately.

[This PR](https://github.com/biosistemika/scinote-web/pull/2061) should be checked before that.

### Note:
Not sure if storage has to be per editor (in case of many steps, they
share the same draft), since the use case is that we navigate from the
active editor. If we need separate storage for every editor then we have
to change ids for every TinyMCE field. I expect many problems here. :cry: 