### PR TITLE
[SCI-3870] Change/fix asset locking mechanism

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -449,19 +449,18 @@ class Asset < ApplicationRecord
   # locked?, lock_asset and refresh_lock rely on the asset
   # being locked in the database to prevent race conditions
   def locked?
+    unlock_expired
     !lock.nil?
   end
 
   def lock_asset(lock_string)
     self.lock = lock_string
     self.lock_ttl = Time.now.to_i + LOCK_DURATION
-    delay(queue: :assets, run_at: LOCK_DURATION.seconds.from_now).unlock_expired
     save!
   end
 
   def refresh_lock
     self.lock_ttl = Time.now.to_i + LOCK_DURATION
-    delay(queue: :assets, run_at: LOCK_DURATION.seconds.from_now).unlock_expired
     save!
   end
 
@@ -473,7 +472,7 @@ class Asset < ApplicationRecord
 
   def unlock_expired
     with_lock do
-      if !lock_ttl.nil? && lock_ttl >= Time.now.to_i
+      if !lock_ttl.nil? && lock_ttl <= Time.now.to_i
         self.lock = nil
         self.lock_ttl = nil
         save!

--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -472,7 +472,7 @@ class Asset < ApplicationRecord
 
   def unlock_expired
     with_lock do
-      if !lock_ttl.nil? && lock_ttl <= Time.now.to_i
+      if !lock_ttl.nil? && lock_ttl < Time.now.to_i
         self.lock = nil
         self.lock_ttl = nil
         save!


### PR DESCRIPTION
Close SCI-3870

Jira ticket: [SCI-3870](https://biosistemika.atlassian.net/browse/SCI-3870)

### What was done
When investigating the above ticket I found out that one of the asset is locked in the mentioned protocol. I believe the current asset locking implementation is bugged, especially with the wrong comparing sign in `unlock_expired`. This probably caused the aforementioned asset to be locked indefinitely. Additionally I am not sure if that `delay` is even needed. RFC
