### PR TITLE
[SCI-3920] Add omniauth initializer

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,7 @@
+require 'omniauth-linkedin-oauth2'
+
+if Rails.configuration.x.enable_user_registration
+  Rails.application.config.middleware.use OmniAuth::Builder do
+    provider :linkedin, ENV['LINKEDIN_KEY'], ENV['LINKEDIN_SECRET']
+  end
+end


### PR DESCRIPTION
Close SCI-3920

Jira ticket: [SCI-3920](https://biosistemika.atlassian.net/browse/SCI-3920)

### What was done
An attempt to solve `scope` not found error. I tried changing `devise.rb` initializer only but it did not work, so I am not sure what is going on. Probably this is related to LinkedIn discontinuing use of API 1.0 which used `basic_profile`. 
