### PR TITLE
Change default executable name for LibreOffice [SCI-3970]

### DIFF
--- a/lib/active_storage/previewer/libreoffice_previewer.rb
+++ b/lib/active_storage/previewer/libreoffice_previewer.rb
@@ -44,7 +44,7 @@ module ActiveStorage
       end
 
       def libreoffice_path
-        ENV['LIBREOFFICE_PATH'] || 'libreoffice'
+        ENV['LIBREOFFICE_PATH'] || 'soffice'
       end
     end
   end


### PR DESCRIPTION
Jira ticket: [SCI-3970](https://biosistemika.atlassian.net/browse/SCI-3970)

### What was done
Change default executable name for LibreOffice

