### PR TITLE
Update sassc gem version to 2.2.1 [SCI-3949]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -502,7 +502,7 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sassc (2.2.0)
+    sassc (2.2.1)
       ffi (~> 1.9)
     sassc-rails (2.1.2)
       railties (>= 4.0.0)


### PR DESCRIPTION
Jira ticket: [SCI-3949](https://biosistemika.atlassian.net/browse/SCI-3949)

### What was done
Update sassc gem version to 2.2.1
