### PR TITLE
External image download improvement [SCI-4077]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'bcrypt', '~> 3.1.10'
 gem 'caracal-rails' # Build docx report
 gem 'commit_param_routing' # Enables different submit actions in the same form
 gem 'deface', '~> 1.0'
+gem 'down', '~> 5.0'
 gem 'faker' # Generate fake data
 gem 'fastimage' # Light gem to get image resolution
 gem 'httparty', '~> 0.13.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -240,6 +240,8 @@ GEM
     docile (1.3.2)
     doorkeeper (5.1.0)
       railties (>= 5)
+    down (5.0.0)
+      addressable (~> 2.5)
     erubi (1.8.0)
     et-orbi (1.2.2)
       tzinfo
@@ -620,6 +622,7 @@ DEPENDENCIES
   devise_invitable
   discard (~> 1.0)
   doorkeeper (>= 4.6)
+  down (~> 5.0)
   factory_bot_rails
   faker
   fastimage


### PR DESCRIPTION
Jira ticket: [SCI-4077](https://biosistemika.atlassian.net/browse/SCI-4077)

### What was done
Add gem Down, File size validation before and during download

### Note
Alternatively, we can implement our custom download and validation in this way...
```
uri = URI(url)
Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
  request = Net::HTTP::Get.new uri

  http.request request do |response|
    open 'large_file', 'wb' do |io|
      response.read_body do |chunk|
        io.write chunk
        puts (io.size/1024/1024)
      end
    end
  end
end
```
But [this gem](https://github.com/janko/down) looks light and does his job. 

>  Down terminates the download very early, as soon as it gets the Content-Length header. And if the Content-Length header is missing, Down will terminate the download as soon as the downloaded content surpasses the maximum size.