### PR TITLE
Add strict order to module tags in modal [SCI-4090]

### DIFF
--- a/app/controllers/my_module_tags_controller.rb
+++ b/app/controllers/my_module_tags_controller.rb
@@ -4,7 +4,7 @@ class MyModuleTagsController < ApplicationController
   before_action :check_manage_permissions, only: %i(create index_edit destroy)
 
   def index_edit
-    @my_module_tags = @my_module.my_module_tags
+    @my_module_tags = @my_module.my_module_tags.order(:id)
     @unassigned_tags = @my_module.unassigned_tags
     @new_mmt = MyModuleTag.new(my_module: @my_module)
     @new_tag = Tag.new(project: @my_module.experiment.project)


### PR DESCRIPTION
Jira ticket: [SCI-4090](https://biosistemika.atlassian.net/browse/SCI-4090)

### What was done
Add strict order to module tags in modal