### PR TITLE
Scroll left on new item in repository datatables [SCI-4236]

### DIFF
--- a/app/assets/javascripts/repositories/row_editor.js
+++ b/app/assets/javascripts/repositories/row_editor.js
@@ -99,6 +99,10 @@ var RepositoryDatatableRowEditor = (function() {
       TABLE.ajax.reload(() => {
         animateSpinner(null, false);
         HelperModule.flashAlertMsg(data.flash, 'success');
+        window.scrollTo({
+          left: 0,
+          behavior: 'smooth'
+        });
       });
     });
 


### PR DESCRIPTION
Jira ticket: [SCI-4236](https://biosistemika.atlassian.net/browse/SCI-4236)

### What was done
Scroll left on a new row/edited row. Smooth is supported by Chrome, not Safari. Good enough.
