### PR TITLE
Fix for items with newline [SCI-4272]

### DIFF
--- a/app/models/repository_checklist_value.rb
+++ b/app/models/repository_checklist_value.rb
@@ -21,7 +21,7 @@ class RepositoryChecklistValue < ApplicationRecord
   end
 
   def export_formatted
-    formatted(separator: "\n")
+    repository_checklist_items.pluck(:data).map { |d| d.tr("\n", ' ') }.join("\n")
   end
 
   def data


### PR DESCRIPTION
Jira ticket: [SCI-4272](https://biosistemika.atlassian.net/browse/SCI-4272)

### Note
Darja hasn't seen all values because excel didn't resize cells automatically. But in case you have different delimiter than "Newline" and you have newline char in item data, it was treated as new item. We are replacing new chars with space now... 