### PR TITLE
Remove academy link from navigation and move about modal to support menu [SCI-4412]

### DIFF
--- a/app/assets/javascripts/navigation.js
+++ b/app/assets/javascripts/navigation.js
@@ -3,12 +3,6 @@
 (function() {
   'use strict';
 
-  /* Init about modal */
-  $("[data-trigger='about-modal']").on('click', function(ev) {
-    ev.preventDefault();
-    $('[data-role=about-modal]').modal('show');
-  });
-
   /* Loading overlay for search */
   $('#search-bar').submit(function() {
     if ($('#update-canvas')) {

--- a/app/assets/stylesheets/themes/main_navigation.scss
+++ b/app/assets/stylesheets/themes/main_navigation.scss
@@ -443,31 +443,3 @@
     }
   }
 }
-
-.academy-link.flag {
-  background: $brand-academy;
-  border: 16px solid $brand-academy;
-  border-bottom: 10px solid $color-white;
-  display: inline-block;
-  height: 0;
-  margin: 0 6px 8px;
-  padding: 12px 0 0;
-  position: relative;
-  width: 0;
-
-  .icon-container {
-    align-items: center;
-    display: flex;
-    height: 28px;
-    justify-content: center;
-    left: -16px;
-    position: absolute;
-    top: -16px;
-    width: 32px;
-
-    .fas {
-      color: $color-white;
-      font-size: 16px;
-    }
-  }
-}

--- a/app/assets/stylesheets/themes/menu_bar.scss
+++ b/app/assets/stylesheets/themes/menu_bar.scss
@@ -75,6 +75,14 @@
     &.open > a {
       color: $color-emperor;
     }
+
+    .about-scinote {
+      font-size: 12px;
+
+      .core-version {
+        color: $color-silver-chalice;
+      }
+    }
   }
 }
 

--- a/app/views/shared/_left_menu_bar.html.erb
+++ b/app/views/shared/_left_menu_bar.html.erb
@@ -81,6 +81,13 @@
           <li><%= link_to t('left_menu_bar.support_links.tutorials'),
                             Constants::TUTORIALS_URL,
                             target: "_blank" %></li>
+          <li role="separator" class="divider" data-hook="support-dropdown-separator">
+          <li>
+            <%= link_to '#', class: "about-scinote", data: { toggle: 'modal', target: '#aboutModal' } do %>
+              <span class="core-version"><%= t('left_menu_bar.support_links.core_version', version: Scinote::Application::VERSION ) %></span>
+              <%= t('left_menu_bar.support_links.about') %>
+            <% end %>
+          </li>
         </ul>
       </li>
       <li class="<%= "active" if settings_are_selected? %>">

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -181,24 +181,7 @@
                           destroy_user_session_path,
                           method: :delete %>
             </li>
-            <li role="separator" class="divider">
-            <li>
-              <%= link_to '#', data: { trigger: 'about-modal' } do %>
-                <%= t('nav.user.about') %>
-              <% end %>
-            </li>
           </ul>
-        </li>
-        <li>
-          <%= link_to Constants::ACADEMY_TR_LINK,
-                      class: "academy-link flag",
-                      title: I18n.t('nav.academy_tooltip'),
-                      target: :_blank do
-          %>
-            <div class="icon-container">
-              <span class="fas fa-graduation-cap"></span>
-            </div>
-          <% end %>
         </li>
       </ul>
     </div>

--- a/config/initializers/constants.rb
+++ b/config/initializers/constants.rb
@@ -208,7 +208,6 @@ class Constants
   DEFAULT_AVATAR_URL = '/images/:style/missing.png'.freeze
 
   ACADEMY_BL_LINK = 'https://scinote.net/academy/?utm_source=SciNote%20software%20BL&utm_medium=SciNote%20software%20BL'.freeze
-  ACADEMY_TR_LINK = 'https://scinote.net/academy/?utm_source=SciNote%20software%20TR&utm_medium=SciNote%20software%20TR'.freeze
 
   #=============================================================================
   # Protocol importers

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -130,7 +130,6 @@ en:
     user:
       settings: "Settings"
       logout: "Log out"
-      about: "About SciNote"
     activities:
       none: "No activities!"
     label:
@@ -161,8 +160,10 @@ en:
     academy: "Academy"
     support: "Support"
     support_links:
-      support: "Support Center"
+      support: "Knowledge center"
       tutorials: "Video tutorials"
+      core_version: "SciNote Core ver. %{version} |"
+      about: "about"
 
   sidebar:
     title: "Navigation"


### PR DESCRIPTION
Jira ticket: [SCI-4412](https://biosistemika.atlassian.net/browse/SCI-4412)

Check also: [PR](https://gitlab.com/biosistemika/scinote/addons/Common/-/merge_requests/89)

### What was done
- academy link was removed from navigation
- about scinote modal was moved to support menu