### PR TITLE
Remove redundant data-hook from protocol options dropdown [SCI-4493]

### DIFF
--- a/app/views/my_modules/protocols/_protocol_options_dropdown.html.erb
+++ b/app/views/my_modules/protocols/_protocol_options_dropdown.html.erb
@@ -39,7 +39,6 @@
     <li>
       <a id="protocol-copy-to-repository"
          data-action="copy-to-repository"
-         data-hook="protocol-copy-to-repository"
          class="<%= 'disabled' unless protocol_savable_to_repo %>"
          data-remote="true"
          href="<%= protocol_savable_to_repo ? copy_to_repository_modal_protocol_path(@protocol, format: :json) : '#' %>">


### PR DESCRIPTION
Jira ticket: [SCI-4493](https://biosistemika.atlassian.net/browse/SCI-4493)

We don't need this data-hook, because of changes in addon [PR](https://gitlab.com/biosistemika/scinote/addons/electronic_signatures/-/merge_requests/63)