### PR TITLE
Remove :not_shared permission level for TeamRepository entity [SCI-4853]

### DIFF
--- a/app/models/team_repository.rb
+++ b/app/models/team_repository.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TeamRepository < ApplicationRecord
-  enum permission_level: Extends::SHARED_INVENTORIES_PERMISSION_LEVELS
+  enum permission_level: Extends::SHARED_INVENTORIES_PERMISSION_LEVELS.except(:not_shared)
 
   belongs_to :team
   belongs_to :repository


### PR DESCRIPTION
Jira ticket: [SCI-4853](https://biosistemika.atlassian.net/browse/SCI-4853)

[GitLab PR](https://gitlab.com/biosistemika/scinote/addons/organization_management/-/merge_requests/96)

### Note
Darja had few inventories from Aug2019 shared with the level of permission sharing 0 = :not_shared. 

This is why she had a few UI bugs (wrong labels, markers about sharing, error on inventory click) 
I remove this ENUM for TeamRepository because when it is unshared, relation is deleted. 
Check also migration in GitLab for removing invalid shares.