### PR TITLE
Extend asset API upload to support base64 [SCI-4813]

### DIFF
--- a/app/controllers/api/v1/assets_controller.rb
+++ b/app/controllers/api/v1/assets_controller.rb
@@ -28,7 +28,7 @@ module Api
           blob = ActiveStorage::Blob.create_after_upload!(
             io: StringIO.new(Base64.decode64(asset_params[:file_data])),
             filename: asset_params[:file_name],
-            content_type: asset_params[:content_type]
+            content_type: asset_params[:file_type]
           )
           asset = @step.assets.new(file: blob)
         end
@@ -48,7 +48,7 @@ module Api
 
         return params.require(:data).require(:attributes).permit(:file) if @form_multipart_upload
 
-        attr_list = %i(file_data content_type file_name)
+        attr_list = %i(file_data file_type file_name)
         params.require(:data).require(:attributes).require(attr_list)
         params.require(:data).require(:attributes).permit(attr_list)
       end
@@ -59,7 +59,7 @@ module Api
       end
 
       def check_upload_type
-        @form_multipart_upload = true if params.dig(:data, :attributes)[:file]
+        @form_multipart_upload = true if params.dig(:data, :attributes, :file)
       end
     end
   end

--- a/spec/requests/api/v1/assets_controller_spec.rb
+++ b/spec/requests/api/v1/assets_controller_spec.rb
@@ -27,13 +27,13 @@ RSpec.describe 'Api::V1::AssetsController', type: :request do
         create(:step_asset, step: @step, asset: asset)
 
         get(api_v1_team_project_experiment_task_protocol_step_assets_path(
-              team_id: @team.id,
-              project_id: @project.id,
-              experiment_id: @experiment.id,
-              task_id: @task.id,
-              protocol_id: @protocol.id,
-              step_id: @step.id
-            ), headers: @valid_headers)
+          team_id: @team.id,
+          project_id: @project.id,
+          experiment_id: @experiment.id,
+          task_id: @task.id,
+          protocol_id: @protocol.id,
+          step_id: @step.id
+        ), headers: @valid_headers)
 
         expect(response).to have_http_status(200)
       end
@@ -42,13 +42,13 @@ RSpec.describe 'Api::V1::AssetsController', type: :request do
     context 'when protocol is not found' do
       it 'renders 404' do
         get(api_v1_team_project_experiment_task_protocol_step_assets_path(
-              team_id: @team.id,
-              project_id: @project.id,
-              experiment_id: @experiment.id,
-              task_id: @task.id,
-              protocol_id: -1,
-              step_id: @step.id
-            ), headers: @valid_headers)
+          team_id: @team.id,
+          project_id: @project.id,
+          experiment_id: @experiment.id,
+          task_id: @task.id,
+          protocol_id: -1,
+          step_id: @step.id
+        ), headers: @valid_headers)
 
         expect(response).to have_http_status(404)
       end
@@ -61,14 +61,14 @@ RSpec.describe 'Api::V1::AssetsController', type: :request do
         create(:step_asset, step: @step, asset: asset)
 
         get(api_v1_team_project_experiment_task_protocol_step_asset_path(
-              team_id: @team.id,
-              project_id: @project.id,
-              experiment_id: @experiment.id,
-              task_id: @task.id,
-              protocol_id: @protocol.id,
-              step_id: @step.id,
-              id: asset.id
-            ), headers: @valid_headers)
+          team_id: @team.id,
+          project_id: @project.id,
+          experiment_id: @experiment.id,
+          task_id: @task.id,
+          protocol_id: @protocol.id,
+          step_id: @step.id,
+          id: asset.id
+        ), headers: @valid_headers)
 
         expect(response).to have_http_status(200)
       end
@@ -77,14 +77,14 @@ RSpec.describe 'Api::V1::AssetsController', type: :request do
     context 'when experiment is not found' do
       it 'renders 404' do
         get(api_v1_team_project_experiment_task_protocol_step_asset_path(
-              team_id: @team.id,
-              project_id: @project.id,
-              experiment_id: -1,
-              task_id: @task.id,
-              protocol_id: @protocol.id,
-              step_id: @step.id,
-              id: asset.id
-            ), headers: @valid_headers)
+          team_id: @team.id,
+          project_id: @project.id,
+          experiment_id: -1,
+          task_id: @task.id,
+          protocol_id: @protocol.id,
+          step_id: @step.id,
+          id: asset.id
+        ), headers: @valid_headers)
 
         expect(response).to have_http_status(404)
       end
@@ -93,14 +93,14 @@ RSpec.describe 'Api::V1::AssetsController', type: :request do
     context 'when asset is not found' do
       it 'renders 404' do
         get(api_v1_team_project_experiment_task_protocol_step_asset_path(
-              team_id: @team.id,
-              project_id: @project.id,
-              experiment_id: @experiment.id,
-              task_id: @task.id,
-              protocol_id: @protocol.id,
-              step_id: @step.id,
-              id: -1
-            ), headers: @valid_headers)
+          team_id: @team.id,
+          project_id: @project.id,
+          experiment_id: @experiment.id,
+          task_id: @task.id,
+          protocol_id: @protocol.id,
+          step_id: @step.id,
+          id: -1
+        ), headers: @valid_headers)
 
         expect(response).to have_http_status(404)
       end
@@ -113,49 +113,82 @@ RSpec.describe 'Api::V1::AssetsController', type: :request do
     end
 
     before :each do
-      @file = fixture_file_upload('files/test.jpg', 'image/jpg')
       allow_any_instance_of(Asset).to receive(:post_process_file)
     end
 
     let(:action) do
       post(api_v1_team_project_experiment_task_protocol_step_assets_path(
-             team_id: @team.id,
-             project_id: @project.id,
-             experiment_id: @experiment.id,
-             task_id: @task.id,
-             protocol_id: @protocol.id,
-             step_id: @step.id
-           ),
+        team_id: @team.id,
+        project_id: @project.id,
+        experiment_id: @experiment.id,
+        task_id: @task.id,
+        protocol_id: @protocol.id,
+        step_id: @step.id
+      ),
            params: request_body,
            headers: @valid_headers)
     end
+    let(:request_body) do
+      {
+        data: {
+          type: 'attachments',
+          attributes: attributes
+        }
+      }
+    end
 
     context 'when has valid params' do
-      let(:request_body) do
-        {
-          data: {
-            type: 'attachments',
-            attributes: {
-              file: @file
-            }
+      context 'when multipart form' do
+        let(:file) { fixture_file_upload('files/test.jpg', 'image/jpg') }
+        let(:attributes) { { file: file } }
+
+        it 'creates new asset' do
+          expect { action }.to change { Asset.count }.by(1)
+        end
+
+        it 'returns status 201' do
+          action
+
+          expect(response).to have_http_status 201
+        end
+
+        it 'calls post_process_file function for text extraction' do
+          expect_any_instance_of(Asset).to receive(:post_process_file)
+
+          action
+        end
+      end
+
+      context 'when base64 with json' do
+        let(:filedata_base64) do
+          'iVBORw0KGgoAAAANSUhEUgAAAAIAA'\
+          'AACCAIAAAD91JpzAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAE0lE'\
+          'QVQIHWP8//8/AwMDExADAQAkBgMBOOSShwAAAABJRU5ErkJggg=='
+        end
+        let(:attributes) do
+          {
+            file_data: filedata_base64,
+            file_name: 'file.png',
+            content_type: 'image/png'
           }
-        }
-      end
+        end
+        let(:request_body) { super().to_json }
 
-      it 'creates new asset' do
-        expect { action }.to change { Asset.count }.by(1)
-      end
+        it 'creates new asset' do
+          expect { action }.to change { Asset.count }.by(1)
+        end
 
-      it 'returns status 201' do
-        action
+        it 'returns status 201' do
+          action
 
-        expect(response).to have_http_status 201
-      end
+          expect(response).to have_http_status 201
+        end
 
-      it 'calls post_process_file function for text extraction' do
-        expect_any_instance_of(Asset).to receive(:post_process_file)
+        it 'calls post_process_file function for text extraction' do
+          expect_any_instance_of(Asset).to receive(:post_process_file)
 
-        action
+          action
+        end
       end
     end
 

--- a/spec/requests/api/v1/assets_controller_spec.rb
+++ b/spec/requests/api/v1/assets_controller_spec.rb
@@ -165,13 +165,7 @@ RSpec.describe 'Api::V1::AssetsController', type: :request do
           'AACCAIAAAD91JpzAAAACXBIWXMAAC4jAAAuIwF4pT92AAAAE0lE'\
           'QVQIHWP8//8/AwMDExADAQAkBgMBOOSShwAAAABJRU5ErkJggg=='
         end
-        let(:attributes) do
-          {
-            file_data: filedata_base64,
-            file_name: 'file.png',
-            content_type: 'image/png'
-          }
-        end
+        let(:attributes) { { file_data: filedata_base64, file_name: 'file.png', file_type: 'image/png' } }
         let(:request_body) { super().to_json }
 
         it 'creates new asset' do
@@ -193,15 +187,7 @@ RSpec.describe 'Api::V1::AssetsController', type: :request do
     end
 
     context 'when has missing param' do
-      let(:request_body) do
-        {
-          data: {
-            type: 'attachments',
-            attributes: {
-            }
-          }
-        }
-      end
+      let(:request_body) { { data: { type: 'attachments', attributes: {} } } }
 
       it 'renders 400' do
         action


### PR DESCRIPTION
Jira ticket: [SCI-4813](https://biosistemika.atlassian.net/browse/SCI-4813)

### What was done
Refactored update and create actions on: 
- Attachments controller
- Results controller (for File Result) 
Now accepts previous behavior (multipart form) and new base64 encoded file 
- In docs only Base64

### Docs:
Check https://github.com/biosistemika/scinote-api-v1-docs/pull/20