### PR TITLE
Fix updating updated_at on protocol while load/sync with repository [SCI-5067]

### DIFF
--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -325,7 +325,7 @@ class ProtocolsController < ApplicationController
           @protocol.unlink
         rescue Exception
           transaction_error = true
-          raise ActiveRecord:: Rollback
+          raise ActiveRecord::Rollback
         end
       end
 
@@ -353,13 +353,11 @@ class ProtocolsController < ApplicationController
       if @protocol.can_destroy?
         transaction_error = false
         Protocol.transaction do
-          begin
-            # Revert is basically update from parent
-            @protocol.update_from_parent(current_user)
-          rescue Exception
-            transaction_error = true
-            raise ActiveRecord:: Rollback
-          end
+          # Revert is basically update from parent
+          @protocol.update_from_parent(current_user)
+        rescue StandardError
+          transaction_error = true
+          raise ActiveRecord::Rollback
         end
 
         if transaction_error
@@ -397,12 +395,10 @@ class ProtocolsController < ApplicationController
       if @protocol.parent.can_destroy?
         transaction_error = false
         Protocol.transaction do
-          begin
-            @protocol.update_parent(current_user)
-          rescue Exception
-            transaction_error = true
-            raise ActiveRecord:: Rollback
-          end
+          @protocol.update_parent(current_user)
+        rescue StandardError
+          transaction_error = true
+          raise ActiveRecord::Rollback
         end
 
         if transaction_error
@@ -440,12 +436,10 @@ class ProtocolsController < ApplicationController
       if @protocol.can_destroy?
         transaction_error = false
         Protocol.transaction do
-          begin
-            @protocol.update_from_parent(current_user)
-          rescue Exception
-            transaction_error = true
-            raise ActiveRecord:: Rollback
-          end
+          @protocol.update_from_parent(current_user)
+        rescue StandardError
+          transaction_error = true
+          raise ActiveRecord::Rollback
         end
 
         if transaction_error
@@ -483,12 +477,10 @@ class ProtocolsController < ApplicationController
       if @protocol.can_destroy?
         transaction_error = false
         Protocol.transaction do
-          begin
-            @protocol.load_from_repository(@source, current_user)
-          rescue Exception
-            transaction_error = true
-            raise ActiveRecord:: Rollback
-          end
+          @protocol.load_from_repository(@source, current_user)
+        rescue StandardError
+          transaction_error = true
+          raise ActiveRecord::Rollback
         end
 
         if transaction_error

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -524,12 +524,14 @@ class Protocol < ApplicationRecord
   end
 
   def update_parent(current_user)
-    # First, destroy parent's step contents
-    parent.destroy_contents
-    parent.reload
+    ActiveRecord::Base.no_touching do
+      # First, destroy parent's step contents
+      parent.destroy_contents
+      parent.reload
 
-    # Now, clone step contents
-    Protocol.clone_contents(self, parent, current_user, false)
+      # Now, clone step contents
+      Protocol.clone_contents(self, parent, current_user, false)
+    end
 
     # Lastly, update the metadata
     parent.reload
@@ -542,11 +544,13 @@ class Protocol < ApplicationRecord
   end
 
   def update_from_parent(current_user)
-    # First, destroy step contents
-    destroy_contents
+    ActiveRecord::Base.no_touching do
+      # First, destroy step contents
+      destroy_contents
 
-    # Now, clone parent's step contents
-    Protocol.clone_contents(parent, self, current_user, false)
+      # Now, clone parent's step contents
+      Protocol.clone_contents(parent, self, current_user, false)
+    end
 
     # Lastly, update the metadata
     reload
@@ -558,11 +562,13 @@ class Protocol < ApplicationRecord
   end
 
   def load_from_repository(source, current_user)
-    # First, destroy step contents
-    destroy_contents
+    ActiveRecord::Base.no_touching do
+      # First, destroy step contents
+      destroy_contents
 
-    # Now, clone source's step contents
-    Protocol.clone_contents(source, self, current_user, false)
+      # Now, clone source's step contents
+      Protocol.clone_contents(source, self, current_user, false)
+    end
 
     # Lastly, update the metadata
     reload
@@ -588,12 +594,14 @@ class Protocol < ApplicationRecord
     # Don't proceed further if clone is invalid
     return clone if clone.invalid?
 
-    # Okay, clone seems to be valid: let's clone it
-    clone = deep_clone(clone, current_user)
+    ActiveRecord::Base.no_touching do
+      # Okay, clone seems to be valid: let's clone it
+      clone = deep_clone(clone, current_user)
 
-    # If the above operation went well, update published_on
-    # timestamp
-    clone.update(published_on: Time.now) if clone.in_repository_public?
+      # If the above operation went well, update published_on
+      # timestamp
+      clone.update(published_on: Time.zone.now) if clone.in_repository_public?
+    end
 
     # Link protocols if neccesary
     if link_protocols


### PR DESCRIPTION
Jira ticket: [SCI-5067](https://biosistemika.atlassian.net/browse/SCI-5067)

### Note
We have a file with
Step.rb
```
  belongs_to :protocol, inverse_of: :steps, touch: true
...
  before_destroy :cascade_before_destroy
  after_destroy :adjust_positions_after_destroy
```

And this one
Protocol.rb
```
  def load_from_repository(source, current_user)
    # First, destroy step contents
    []
    destroy_contents

    # Now, clone source's step contents
    Protocol.clone_contents(source, self, current_user, false)

    # Lastly, update the metadata
    reload
    self.record_timestamps = false
    self.updated_at = source.updated_at
    self.parent = source
    self.parent_updated_at = source.updated_at
    self.added_by = current_user
    self.protocol_type = Protocol.protocol_types[:linked]
    save!
  end
```
This method is triggered in transaction (`protocols_controller.rb`) 
I assume some of the callbacks of `destroy_contents ` consequently happened when the transaction is committed, with delete steps, and steps are touching protocol over belongs_to relation. This means the callback after the transaction committed overrides the line `self.updated_at = source.updated_at`.


I tried with this: https://api.rubyonrails.org/v6.0.2.1/classes/ActiveRecord/NoTouching/ClassMethods.html
but somehow protocol still been touched. 


