### PR TITLE
Implement ESC button to exit full-screen modals [SCI-5048]

### DIFF
--- a/app/assets/javascripts/my_modules/repositories.js
+++ b/app/assets/javascripts/my_modules/repositories.js
@@ -469,6 +469,7 @@ var MyModuleRepositories = (function() {
       $.getJSON($(this).data('table-url'), (data) => {
         FULL_VIEW_MODAL.find('.table-container').html(data.html);
         renderFullViewTable(FULL_VIEW_MODAL.find('.table'), { assigned: true, skipCheckbox: true });
+        FULL_VIEW_MODAL.focus();
       });
       e.stopPropagation();
     });
@@ -576,6 +577,8 @@ var MyModuleRepositories = (function() {
       submitUpdateRepositoryRecord({ downstream: true });
     }).on('click', '.task-action', function() {
       submitUpdateRepositoryRecord({ downstream: false });
+    }).on('hidden.bs.modal', function() {
+      FULL_VIEW_MODAL.focus();
     });
   }
 

--- a/app/assets/javascripts/sitewide/image_editor.js
+++ b/app/assets/javascripts/sitewide/image_editor.js
@@ -418,3 +418,9 @@ var ImageEditorModal = (function() {
   });
 }());
 ImageEditorModal.init();
+
+$(document).on('keydown', function(e) {
+  if (e.keyCode === 27) {
+    $('#fileEditModal').modal('hide');
+  }
+});

--- a/app/assets/stylesheets/my_modules/protocols/index.scss
+++ b/app/assets/stylesheets/my_modules/protocols/index.scss
@@ -479,8 +479,9 @@
 .task-details-dropdown-container {
   .task-details-button {
     @include font-h2;
-    cursor: pointer;
+    color: inherit;
     margin: 0 3px;
+    text-decoration: none;
   }
 
   .dropdown-menu {

--- a/app/views/my_modules/protocols.html.erb
+++ b/app/views/my_modules/protocols.html.erb
@@ -22,7 +22,14 @@
         </h2>
       </span>
       <span class="dropdown task-details-dropdown-container">
-        <span id="taskDetailsButton" class="fas block-icon fa-info-circle task-details-button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true"></span>
+        <a href="#"
+           id="taskDetailsButton"
+           class="block-icon task-details-button dropdown-toggle"
+           data-toggle="dropdown"
+           aria-haspopup="true"
+           aria-expanded="true">
+          <i class="fas fa-info-circle"></i>
+        </a>
         <div class="dropdown-menu" aria-labelledby="taskDetailsButton">
           <%= render partial: "module_header_details_popover.html.erb" %>
         </div>

--- a/app/views/shared/_file_preview_modal.html.erb
+++ b/app/views/shared/_file_preview_modal.html.erb
@@ -3,9 +3,7 @@
      role="dialog"
      tabindex="-1"
      aria-labelledby="filePreviewModal"
-     aria-hidden="true"
-     data-backdrop="static"
-     data-keyboard="false">
+     aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">

--- a/app/views/shared/file_preview/_modal.html.erb
+++ b/app/views/shared/file_preview/_modal.html.erb
@@ -3,9 +3,7 @@
      role="dialog"
      tabindex="-1"
      aria-labelledby="filePreviewModal"
-     aria-hidden="true"
-     data-backdrop="static"
-     data-keyboard="false">
+     aria-hidden="true">
   <div class="modal-dialog">
     <div class="modal-content">
     </div>


### PR DESCRIPTION
Jira ticket: [SCI-5048](https://biosistemika.atlassian.net/browse/SCI-5048)

### What was done
Fix ESC button to exit elements:
-Image & files full-screen preview, image editor
-"Assign from" modal and "Assigned items-versions" full screen modal
-task details dropdown