### PR TITLE
Folder name uniqueness validation on folder level and renaming [SCI-5312]

### DIFF
--- a/app/assets/javascripts/projects/index.js
+++ b/app/assets/javascripts/projects/index.js
@@ -49,8 +49,9 @@
         HelperModule.flashAlertMsg(data.message, 'success');
         refreshCurrentView();
       })
-      .on('ajax:error', function(e, data) {
-        $(this).renderFormErrors('project_folder', data.responseJSON);
+      .on('ajax:error', newProjectFolderModal, function(e, data) {
+        let form = $(this).find('form#new_project_folder');
+        form.renderFormErrors('project_folder', data.responseJSON);
       });
 
     $(toolbarWrapper)
@@ -79,7 +80,7 @@
         HelperModule.flashAlertMsg(data.message, 'success');
         refreshCurrentView();
       })
-      .on('ajax:error', function(ev, data) {
+      .on('ajax:error', newProjectModal, function(ev, data) {
         $(this).renderFormErrors('project', data.responseJSON);
       });
 


### PR DESCRIPTION
Jira ticket: [SCI-5312](https://biosistemika.atlassian.net/browse/SCI-5312)

Folder name uniqueness validation is moved to the folder level.
Rename folder if a folder with the same name already exists within the folder where will be moved to.