### PR TITLE
[SCI-5635] Report not generated in case of tasks from more experiments

### DIFF
--- a/db/migrate/20210410100006_fix_last_changed_by_on_steps.rb
+++ b/db/migrate/20210410100006_fix_last_changed_by_on_steps.rb
@@ -24,9 +24,9 @@ class FixLastChangedByOnSteps < ActiveRecord::Migration[6.1]
                  .order(created_at: :desc)
                  .first
       if activity && user_id = activity.values.dig('message_items', 'user', 'id')
-        step.update!(last_modified_by_id: user_id)
+        step.update_column(:last_modified_by_id, user_id)
       else
-        step.update!(last_modified_by_id: step.user_id)
+        step.update_column(:last_modified_by_id, step.user_id)
       end
     end
   end


### PR DESCRIPTION
Updated the migration to use update_column, to avoid failing callbacks
