### PR TITLE
Use the same ordering in PDF report for full results file previews as in the main results section [SCI-5742]

### DIFF
--- a/app/jobs/reports/pdf_job.rb
+++ b/app/jobs/reports/pdf_job.rb
@@ -96,7 +96,8 @@ module Reports
     def append_result_asset_previews(report, report_file)
       Dir.mktmpdir do |tmp_dir|
         report.report_elements.my_module.each do |my_module_element|
-          my_module_element.my_module.results.each do |result|
+          results = my_module_element.my_module.results
+          order_results_for_report(results, report.settings.dig(:task, :result_order)).each do |result|
             next unless result.is_asset && PREVIEW_EXTENSIONS.include?(result.asset.file.blob.filename.extension)
 
             asset = result.asset


### PR DESCRIPTION
Jira ticket: [SCI-5742](https://biosistemika.atlassian.net/browse/SCI-5742)

### What was done
Use the same ordering in PDF report for full results file previews as in the main results section