### PR TITLE
Lock repository_row before inserting RepositoryCell  [SCI-5794]

### DIFF
--- a/app/services/report_actions/save_pdf_to_inventory_item.rb
+++ b/app/services/report_actions/save_pdf_to_inventory_item.rb
@@ -11,7 +11,10 @@ module ReportActions
     end
 
     def save
-      ActiveRecord::Base.transaction do
+      # we lock the row, to prevent two repository cells being created at the same location
+      # as the RepositoryCell validation would pass in both concurrent transactions
+
+      @repository_row.with_lock do
         asset = create_new_asset
         delete_old_repository_cell
         @new_cell_value = create_new_cell_value(asset)


### PR DESCRIPTION
Jira ticket: [SCI-5794](https://biosistemika.atlassian.net/browse/SCI-5794)

### What was done
Added a repository_row lock to ReportActions::SavePdfToInventoryItem, to prevent creation of invalid repository cells, caused by concurrent transactions making a validation pass despite issue.

### Note:
Tested on frontend, and by running the service in 5 concurrent threads from the console. Works OK.
