### PR TITLE
Reload report table after triggering doc generation request [SCI-5788]

### DIFF
--- a/app/assets/javascripts/reports/reports_datatable.js
+++ b/app/assets/javascripts/reports/reports_datatable.js
@@ -71,7 +71,7 @@
                   ${I18n.t('projects.reports.index.previous_docx')})
                 </a>`;
       }
-      return `<span class="processing-error">
+      return `<span class="processing-error docx">
                 <i class="fas fa-exclamation-triangle"></i>
                 ${I18n.t('projects.reports.index.error')}${oldLink}
               </span>`;


### PR DESCRIPTION
Jira ticket: [SCI-5788](https://biosistemika.atlassian.net/browse/SCI-5788)

### What was done
Added missing class to status cell, so DOCX report status gets refreshed properly after error.