### PR TITLE
Fix image extension in empty printers modal [SCI-5971]

### DIFF
--- a/app/views/repositories/_print_label_modal.html.erb
+++ b/app/views/repositories/_print_label_modal.html.erb
@@ -35,7 +35,7 @@
         <% end %>
       <% else %>
         <div class="modal-body no-printers-container">
-          <%= image_tag 'printers/no_available_printers' %>
+          <%= image_tag 'printers/no_available_printers.png' %>
           <p class="no-printer-title">
             <%= t('repository_row.modal_print_label.no_printers.title') %>
           </p>


### PR DESCRIPTION
Jira ticket: [SCI-5971](https://biosistemika.atlassian.net/browse/SCI-5971)

### What was done
Fix image extension in empty printers modal
