### PR TITLE
Fixed for assets that belong to protocol step [SCI-5996]

### DIFF
--- a/app/controllers/bio_eddie_assets_controller.rb
+++ b/app/controllers/bio_eddie_assets_controller.rb
@@ -137,7 +137,7 @@ class BioEddieAssetsController < ApplicationController
         activity_type: :register_molecule,
         owner: current_user,
         team: asset.team,
-        project: asset.my_module.experiment.project,
+        project: asset&.my_module&.experiment&.project,
         subject: asset,
         message_items: {
           description: asset.blob.metadata['description'],


### PR DESCRIPTION
Jira ticket: [SCI-5996](https://biosistemika.atlassian.net/browse/SCI-5996)

### What was done
A register_molecule activity doesn't necessarily always belong to a project, it can also belong to a protocol. In this case we leave the project blank.