### PR TITLE
Optimize how printing jobs and statuses work [SCI-5984]

### DIFF
--- a/app/jobs/label_printers/print_job.rb
+++ b/app/jobs/label_printers/print_job.rb
@@ -11,36 +11,33 @@ module LabelPrinters
       label_printer.update!(status: :error)
     end
 
-    def perform(label_printer, payload)
+    def perform(label_printer, payload, copy_count)
       case label_printer.type_of
       when 'fluics'
         api_client = LabelPrinters::Fluics::ApiClient.new(
           label_printer.fluics_api_key
         )
 
-        api_client.print(label_printer.fluics_lid, payload)
+        copy_count.times do
+          response = api_client.print(label_printer.fluics_lid, payload)
 
-        # wait for FLUICS printer to stop being busy
-        MAX_STATUS_UPDATES.times do
-          status =
-            LabelPrinter::FLUICS_STATUS_MAP[
-              api_client.status(label_printer.fluics_lid).dig('printerState', 'printerStatus')
-            ]
+          status = response['status'] == 'OK' ? :ready : LabelPrinter::FLUICS_STATUS_MAP[response['printerStatus']]
           label_printer.update!(status: status)
 
-          break if status == :ready
+          break if status != :ready
 
-          sleep 5
+          # remove first matching job_id from queue (one label out of batch has been printed)
+          label_printer.with_lock do
+            job_ids = label_printer.current_print_job_ids
+            job_ids.delete_at(job_ids.index(job_id) || job_ids.length)
+
+            label_printer.update!(current_print_job_ids: job_ids)
+          end
         end
       end
 
       # mark as unreachable if no final state is reached
-      label_printer.update!(status: :unreachable) unless label_printer.status.in? %w(ready out_of_labels)
-
-      label_printer.with_lock do
-        label_printer.current_print_job_ids.delete(job_id)
-        label_printer.save!
-      end
+      label_printer.update!(status: :unreachable) unless label_printer.status.in? %w(ready out_of_labels error)
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1641,12 +1641,14 @@ en:
         not_ready: "Not Ready"
         out_of_labels: "Out of labels"
         error: "Printer error"
+        unreachable: "Printer offline"
       multiple_items: "%{item_count}/%{starting_item_count} labels"
       printing_status:
         done: "Done"
         printing: "Printing"
         out_of_labels: "Waiting for labels. Please, insert labels."
         error: "There is an issue with the printer."
+        unreachable: "Printer is offline"
   activities:
     index:
       global_activities_title: "Global activities"


### PR DESCRIPTION
Jira ticket: [SCI-5984](https://biosistemika.atlassian.net/browse/SCI-5984)

### What was done
Amended printing to reset all printers on reprint, the job to run label print requests sequentially (instead of multiple jobs), and optimized the way printer status is updated during printing.