### PR TITLE
Merge migrations as 'assigned' is needed in new user roles migration [SCI-6127]

### DIFF
--- a/db/migrate/20210202214508_create_user_roles_and_assignments.rb
+++ b/db/migrate/20210202214508_create_user_roles_and_assignments.rb
@@ -17,6 +17,7 @@ class CreateUserRolesAndAssignments < ActiveRecord::Migration[6.1]
       t.references :user, foreign_key: true, null: false
       t.references :user_role, foreign_key: true, null: false
       t.references :assigned_by, foreign_key: { to_table: :users }, null: true
+      t.integer :assigned, null: false, default: 0
 
       t.timestamps
     end

--- a/db/migrate/20210612070220_add_creation_flag_to_user_assignment.rb
+++ b/db/migrate/20210612070220_add_creation_flag_to_user_assignment.rb
@@ -1,5 +1,0 @@
-class AddCreationFlagToUserAssignment < ActiveRecord::Migration[6.1]
-  def change
-    add_column :user_assignments, :assigned, :integer, null: false, default: 0
-  end
-end


### PR DESCRIPTION
Jira ticket: [SCI-6127](https://biosistemika.atlassian.net/browse/SCI-6127)

### What was done
Merge migrations as 'assigned' is needed in new user roles migration.