### PR TITLE
Fixed cached user lists when changing assignments [SCI-6137]

### DIFF
--- a/app/models/user_assignment.rb
+++ b/app/models/user_assignment.rb
@@ -1,21 +1,10 @@
 # frozen_string_literal: true
 
 class UserAssignment < ApplicationRecord
-  belongs_to :assignable, polymorphic: true
+  belongs_to :assignable, polymorphic: true, touch: true
   belongs_to :user_role
   belongs_to :user
   belongs_to :assigned_by, class_name: 'User', optional: true
 
   enum assigned: { automatically: 0, manually: 1 }, _suffix: true
-
-  after_destroy :touch_assignable
-  after_save :touch_assignable
-
-  private
-
-  def touch_assignable
-    # This busts the cache of cached assigned user lists.
-    # Using .update_column instead of .touch, to avoid triggering an audit trail callback
-    assignable.update_column(:updated_at, Time.zone.now)
-  end
 end

--- a/app/models/user_assignment.rb
+++ b/app/models/user_assignment.rb
@@ -7,4 +7,15 @@ class UserAssignment < ApplicationRecord
   belongs_to :assigned_by, class_name: 'User', optional: true
 
   enum assigned: { automatically: 0, manually: 1 }, _suffix: true
+
+  after_destroy :touch_assignable
+  after_save :touch_assignable
+
+  private
+
+  def touch_assignable
+    # This busts the cache of cached assigned user lists.
+    # Using .update_column instead of .touch, to avoid triggering an audit trail callback
+    assignable.update_column(:updated_at, Time.zone.now)
+  end
 end

--- a/app/views/access_permissions/experiments/modals/_edit_modal.html.erb
+++ b/app/views/access_permissions/experiments/modals/_edit_modal.html.erb
@@ -15,7 +15,7 @@
         <% users.each do |user| %>
           <% user_assignment = experiment.user_assignments.find_by(user: user) %>
 
-          <% cache [user_assignment, experiment, user] do %>
+          <% cache [user_assignment, experiment, user, current_user] do %>
             <%= render partial: 'access_permissions/partials/experiment_member_field',
                        locals: {
                          user: user,

--- a/app/views/access_permissions/my_modules/modals/_edit_modal.html.erb
+++ b/app/views/access_permissions/my_modules/modals/_edit_modal.html.erb
@@ -15,7 +15,7 @@
         <% users.each do |user| %>
           <% user_assignment = my_module.user_assignments.find_by(user: user) %>
 
-          <% cache [user_assignment, my_module, user] do %>
+          <% cache [user_assignment, my_module, user, current_user] do %>
             <%= render partial: 'access_permissions/partials/my_module_member_field',
                        locals: {
                          user: user,


### PR DESCRIPTION
Jira ticket: [SCI-6137](https://biosistemika.atlassian.net/browse/SCI-6137)

### What was done
Fixed cached project users lists, by touching assignables on asignment changes.