### PR TITLE
Removed ExperimentPermissions::USERS_MANAGE permission for normal user role [SCI-6172]

### DIFF
--- a/config/initializers/extends/permission_extends.rb
+++ b/config/initializers/extends/permission_extends.rb
@@ -103,7 +103,7 @@ module PermissionExtends
       ExperimentPermissions::READ_CANVAS,
       ExperimentPermissions::MANAGE,
       ExperimentPermissions::TASKS_MANAGE,
-      ExperimentPermissions::USERS_MANAGE,
+      ExperimentPermissions::USERS_READ,
       MyModulePermissions::READ,
       MyModulePermissions::MANAGE,
       MyModulePermissions::RESULTS_MANAGE,


### PR DESCRIPTION
Jira ticket: [SCI-6172](https://biosistemika.atlassian.net/browse/SCI-6172)

### What was done
Removed ExperimentPermissions::USERS_MANAGE permission for normal user role