### PR TITLE
Fixed bug in _invite_users_modal_results.html.erb

### DIFF
--- a/app/views/shared/_invite_users_modal_results.html.erb
+++ b/app/views/shared/_invite_users_modal_results.html.erb
@@ -4,6 +4,9 @@
 <hr />
 <div class="results-wrap">
 <% @invite_results.each do |result| %>
+<% @team = Team.find(result[:user_teams].first.team_id).name %>
+<% @role = result[:user_teams].first.role %>
+
 <%   if result[:status] == :user_exists %>
   <div class="alert alert-info" role="alert">
     <strong><%= result[:email] %></strong>
@@ -15,24 +18,24 @@
     <strong><%= result[:email] %></strong>
     &nbsp;-&nbsp;
     <%= t('invite_users.results.user_exists_and_in_team',
-          team: @team.name,
-          role: t("user_teams.enums.role.#{result[:user_team].role}")) %>
+          team: @team,
+          role: t("user_teams.enums.role.#{@role}")) %>
   </div>
 <%   elsif result[:status] == :user_exists_unconfirmed_invited_to_team %>
   <div class="alert alert-info" role="alert">
     <strong><%= result[:email] %></strong>
     &nbsp;-&nbsp;
     <%= t('invite_users.results.user_exists_unconfirmed_invited_to_team',
-          team: @team.name,
-          role: t("user_teams.enums.role.#{result[:user_team].role}")) %>
+          team: @team,
+          role: t("user_teams.enums.role.#{@role}")) %>
   </div>
 <%   elsif result[:status] == :user_exists_invited_to_team %>
   <div class="alert alert-info" role="alert">
     <strong><%= result[:email] %></strong>
     &nbsp;-&nbsp;
     <%= t('invite_users.results.user_exists_invited_to_team',
-          team: @team.name,
-          role: t("user_teams.enums.role.#{result[:user_team].role}")) %>
+          team: @team,
+          role: t("user_teams.enums.role.#{@role}")) %>
 </div>
 <%   elsif result[:status] == :user_created %>
   <div class="alert alert-success" role="alert">
@@ -45,8 +48,8 @@
     <strong><%= result[:email] %></strong>
     &nbsp;-&nbsp;
     <%= t('invite_users.results.user_created_invited_to_team',
-          team: @team.name,
-          role: t("user_teams.enums.role.#{result[:user_team].role}")) %>
+          team: @team,
+          role: t("user_teams.enums.role.#{@role}")) %>
 </div>
 <%   elsif result[:status] == :user_invalid %>
   <div class="alert alert-danger" role="alert">


### PR DESCRIPTION
### What was done
Fixed bug in _invite_users_modal_results.html.erb
the bug: when inviting users, after a new user is generated (if needed) and email is sent, an error occurs in the partial responsible for generating the "all is done" message, so that instead of "all is done" one sees "error inviting users", even though the users have been invited successfully. 
The reason for the error is the mismatch between the expected structure of @invite_results and the actual @invite_results.

