### PR TITLE
Remove invalid designated users when moving experiment [SCI-6335]

### DIFF
--- a/app/services/experiments/move_to_project_service.rb
+++ b/app/services/experiments/move_to_project_service.rb
@@ -31,6 +31,7 @@ module Experiments
             raise
           end
           sync_user_assignments(my_module)
+          clean_up_user_my_modules(my_module)
           move_tags!(my_module)
         end
 
@@ -117,6 +118,10 @@ module Experiments
       )
 
       UserAssignments::GenerateUserAssignmentsJob.perform_later(object, @user)
+    end
+
+    def clean_up_user_my_modules(my_module)
+      my_module.user_my_modules.where.not(user_id: @project.users.select(:id)).destroy_all
     end
 
     def track_activity


### PR DESCRIPTION
Jira ticket: [SCI-6335](https://biosistemika.atlassian.net/browse/SCI-6335)

### What was done
Added cleanup of users not belonging to project, that are designated on a task.