### PR TITLE
Fix propagation and display of role on experiment role reset [SCI-6337]

### DIFF
--- a/app/assets/stylesheets/access_permissions/access_modal.scss
+++ b/app/assets/stylesheets/access_permissions/access_modal.scss
@@ -24,14 +24,6 @@
     width: 200px;
   }
 
-  .permission-object-tag {
-    @include font-small;
-    background: $color-concrete;
-    border-radius: $border-radius-tag;
-    cursor: pointer;
-    padding: .25em;
-  }
-
   .member-item,
   .user-assignment-info,
   .user-assignment-controls {
@@ -76,4 +68,12 @@
   hr {
     margin: 1em 0;
   }
+}
+
+.permission-object-tag {
+  @include font-small;
+  background: $color-concrete;
+  border-radius: $border-radius-tag;
+  cursor: pointer;
+  padding: .25em;
 }

--- a/app/models/experiment_member.rb
+++ b/app/models/experiment_member.rb
@@ -47,6 +47,14 @@ class ExperimentMember
                    .user_role
 
       user_assignment.update!(user_role: @user_role, assigned: :automatically)
+
+      UserAssignments::PropagateAssignmentJob.perform_later(
+        @experiment,
+        @user,
+        user_role,
+        current_user
+      )
+
       log_change_activity
     end
   end

--- a/app/views/user_my_modules/_index_old.html.erb
+++ b/app/views/user_my_modules/_index_old.html.erb
@@ -15,8 +15,11 @@
             </span>
           </div>
           <div class="col-xs-10" style="line-height: 15px">
-            <span><%= user.full_name %></span><br>
-            <span class="user-role"><%= @my_module.role_for_user(user).name %></span>
+            <span><%= user.full_name %></span>
+            <br>
+            <span class="user-role">
+              <small class="text-muted"><%= user_assignment_resource_role_name(user, user_my_module.my_module) %></small>
+            </span>
           </div>
         </div>
       </li>


### PR DESCRIPTION
Jira ticket: [SCI-6337](https://biosistemika.atlassian.net/browse/SCI-6337)

### What was done
Added missing propagation call on experiment member role reset, made display of role consistent between task access modal and task designated users dropdown.