### PR TITLE
Use the last status flow as a default one for new tasks [SCI-6098]

### DIFF
--- a/app/models/my_module.rb
+++ b/app/models/my_module.rb
@@ -438,7 +438,7 @@ class MyModule < ApplicationRecord
   def assign_default_status_flow
     return if my_module_status.present? || MyModuleStatusFlow.global.blank?
 
-    self.my_module_status = MyModuleStatusFlow.global.first.initial_status
+    self.my_module_status = MyModuleStatusFlow.global.last.initial_status
   end
 
   def check_status_conditions


### PR DESCRIPTION
Jira ticket: [SCI-6098](https://biosistemika.atlassian.net/browse/SCI-6098)

### What was done
Use the last status flow as a default one for new tasks