### PR TITLE
Lock psych version to < 4.0, until upgrade to rails 7 [SCI-6403]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'devise_invitable'
 gem 'figaro'
 gem 'pg', '~> 1.1'
 gem 'pg_search' # PostgreSQL full text search
+gem 'psych', '< 4.0'
 gem 'rails', '~> 6.1.1'
 gem 'view_component', require: 'view_component/engine'
 gem 'recaptcha', require: 'recaptcha/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -439,6 +439,7 @@ GEM
       pry (~> 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    psych (3.3.2)
     public_suffix (4.0.6)
     puma (5.5.2)
       nio4r (~> 2.0)
@@ -703,6 +704,7 @@ DEPENDENCIES
   pry
   pry-byebug
   pry-rails
+  psych (< 4.0)
   puma
   rack-attack
   rack-cors


### PR DESCRIPTION
Jira ticket: [SCI-6403](https://biosistemika.atlassian.net/browse/SCI-6403)

### What was done
Lock psych version to < 4.0, until upgrade to rails 7