### PR TITLE
Enable experiment duplicate for viewer and technician role and UI experiment action changes [SCI-6756]

### DIFF
--- a/app/assets/stylesheets/projects.scss
+++ b/app/assets/stylesheets/projects.scss
@@ -27,6 +27,14 @@ $color-module-hover: $brand-primary;
 
   .actions-button {
     margin-right: 15px;
+
+    .fas {
+      margin-right: .4em;
+    }
+
+    a {
+      padding: .5em 1em;
+    }
   }
 
   .toolbarButtons {

--- a/app/permissions/experiment.rb
+++ b/app/permissions/experiment.rb
@@ -72,7 +72,7 @@ Canaid::Permissions.register_for(Experiment) do
   end
 
   can :clone_experiment do |user, experiment|
-    experiment.permission_granted?(user, ExperimentPermissions::MANAGE)
+    experiment.permission_granted?(user, ExperimentPermissions::READ)
   end
 
   can :move_experiment do |user, experiment|

--- a/app/views/experiments/_dropdown_actions.html.erb
+++ b/app/views/experiments/_dropdown_actions.html.erb
@@ -3,48 +3,64 @@
   data-id="<%= experiment.id %>">
 
   <% if can_manage_experiment?(experiment) %>
-  <li><%= link_to t('experiments.edit.label_title'),
-                edit_experiment_url(experiment),
-                remote: true,
-                type: 'button',
-                data: { id: experiment.id },
-                class: 'edit-experiment' %></li>
+    <li>
+      <%= link_to edit_experiment_url(experiment),
+                  remote: true,
+                  type: 'button',
+                  data: { id: experiment.id },
+                  class: 'edit-experiment' do %>
+        <i class="fas fa-pen"></i>
+        <span><%= t('experiments.edit.label_title') %></span>
+      <% end %>          
+    </li>
   <% end %>
   <li data-hook="experiment-actions-second-child"></li>
   <% if can_clone_experiment?(experiment) %>
-    <li><%= link_to t('experiments.clone.label_title'),
-                    clone_modal_experiment_url(experiment),
-                    remote: true, type: 'button',
-                    class: 'clone-experiment' %>
+    <li>
+      <%= link_to clone_modal_experiment_url(experiment),
+                  remote: true, type: 'button',
+                  class: 'clone-experiment' do %>
+        <i class="fas fa-copy"></i>
+        <span><%= t('experiments.clone.label_title') %></span>
+      <% end %>   
     </li>
   <% end %>
   <% if can_move_experiment?(experiment) %>
-    <li><%= link_to t('experiments.move.label_title'),
-                    move_modal_experiment_url(experiment),
-                    remote: true, type: 'button',
-                    class: 'move-experiment'%>
+    <li>
+      <%= link_to move_modal_experiment_url(experiment),
+                  remote: true, type: 'button',
+                  class: 'move-experiment' do %>
+        <i class="fas fa-arrow-right"></i>
+        <span><%= t('experiments.move.label_title') %></span>
+      <% end %>   
     </li>
   <% end %>
   <!-- Set or view user experiment assignments -->
   <% if can_manage_experiment_users?(experiment) %>
     <li>
       <%= link_to edit_access_permissions_project_experiment_path(project, experiment), data: { action: 'remote-modal'} do %>
+        <i class="fas fa-door-open"></i>
         <span><%= t('experiments.index.experiment_access') %></span>
       <% end %>
     </li>
   <% else %>
     <li>
       <%= link_to access_permissions_project_experiment_path(project, experiment), data: { action: 'remote-modal'} do %>
+        <i class="fas fa-door-open"></i>
         <span><%= t('experiments.index.experiment_access') %></span>
       <% end %>
     </li>
   <% end %>
   <% if can_archive_experiment?(experiment) %>
-    <li><%= link_to t('experiments.archive.label_title'),
-                  archive_experiment_url(experiment),
+    <li>
+      <%= link_to archive_experiment_url(experiment),
                   type: 'button',
                   method: :post,
-                  data: { confirm: t('experiments.canvas.archive_confirm') } %></li>
+                  data: { confirm: t('experiments.canvas.archive_confirm') } do %>
+        <i class="fas fa-archive"></i>
+        <span><%= t('experiments.archive.label_title') %></span>
+      <% end %>   
+    </li>
   <% end %>
   <% if can_restore_experiment?(experiment) %>
     <% experiment_form = nil %>
@@ -52,6 +68,12 @@
       <% experiment_form = f %>
       <%= f.hidden_field :archived, value: false %>
     <% end %>
-    <li><a href="#" class="form-submit-link" data-turbolinks="false" data-submit-form="<%= experiment_form.options[:html][:id] %>"><%= t "projects.experiment_archive.restore_option" %></a></li>
+    <li><a href="#" class="form-submit-link" data-turbolinks="false" data-submit-form="<%= experiment_form.options[:html][:id] %>">
+          <i class="fas fa-undo"></i><%= t "projects.experiment_archive.restore_option" %></a></li>
   <% end %>
+  <li class="form-dropdown-item">
+    <div class="form-dropdown-item-info">
+      <small><%= t('experiments.experiment_id') %>: <strong><%= experiment.code %></strong></small>
+    </div>
+  </li>
 </ul>

--- a/app/views/experiments/canvas.html.erb
+++ b/app/views/experiments/canvas.html.erb
@@ -21,6 +21,8 @@
                   <span class="fas fa-pencil-alt"></span>
                   <span class="hidden-xs"><%=t 'experiments.canvas.canvas_edit' %></span>
                 <% end %>
+        <% end %>
+        <% if can_manage_experiment?(@experiment) || can_clone_experiment?(@experiment)  %>
           <!-- experiment actions -->
           <span class="dropdown actions-button">
             <button class="btn btn-secondary dropdown-toggle" type="button" id="exActionsMenu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1092,7 +1092,7 @@ en:
       more: "more"
     index:
       edit_option: "Edit details"
-      clone_option: "Duplicate (as template)"
+      clone_option: "Duplicate as template"
       move_option: "Move"
       archive_option: "Archive"
       archive_confirm: "Are you sure you want to archive this project?"
@@ -1134,11 +1134,11 @@ en:
       success_flash: "<strong>%{number}</strong> experiment(s) successfully restored."
       error_flash: "Failed to restore experiment(s)."
     clone:
-      modal_title: 'Copy experiment %{experiment} as template'
-      label_title: 'Copy as template'
-      modal_submit: 'Copy'
-      success_flash: 'Successfully copied experiment %{experiment} as template.'
-      error_flash: 'Could not copy the experiment as template.'
+      modal_title: 'Duplicate experiment %{experiment} as template'
+      label_title: 'Duplicate as template'
+      modal_submit: 'Duplicate'
+      success_flash: 'Successfully duplicated experiment %{experiment} as template.'
+      error_flash: 'Could not duplicate the experiment as template.'
       current_project: '(current project)'
     move:
       modal_title: 'Move experiment %{experiment}'


### PR DESCRIPTION
Jira ticket: [SCI-6756](https://biosistemika.atlassian.net/browse/SCI-6756)

### What was done
- Read permission for duplicating experiments
- Wording changes
- Add icons to the experiment canvas actions dropdown menu