### PR TITLE
Fix linked protocol naming and i icon flyout [SCI-6963]

### DIFF
--- a/app/assets/stylesheets/my_modules/protocol.scss
+++ b/app/assets/stylesheets/my_modules/protocol.scss
@@ -19,6 +19,18 @@
   .portocol-header-left-part {
     align-items: baseline;
     display: flex;
+
+    .task-section-caret {
+      padding-right: .25em;
+    }
+
+    .status-label {
+      margin: 2px 0 0;
+    }
+
+    .status-info {
+      padding-left: 4px;
+    }
   }
 
   .insert-step {

--- a/app/assets/stylesheets/my_modules/protocols/index.scss
+++ b/app/assets/stylesheets/my_modules/protocols/index.scss
@@ -637,6 +637,8 @@
       width: 300px;
 
       .dropdown-footer {
+        display: block;
+
         .btn {
           float: left !important;
           margin: 5px 0;

--- a/app/views/my_modules/protocols/_protocol_status_bar.html.erb
+++ b/app/views/my_modules/protocols/_protocol_status_bar.html.erb
@@ -1,7 +1,7 @@
 <div class="dropdown my-module-protocol-status">
   <% if @protocol.linked? %>
     <span class="status-label linked">
-      [<%= protocol_name(@protocol.parent) %>]
+      [<%= t("my_modules.protocols.protocol_status_bar.linked") %>]
     </span>
   <% else %>
     <span class="status-label">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -877,6 +877,7 @@ en:
       protocol_status_bar:
         private_parent: "private"
         unlinked: "unlinked"
+        linked: "linked"
         no_description: "No protocol description"
         enter_name: "Enter protocol name"
         empty_description_edit_label: "Click here to enter Protocol Description (optional)"
@@ -895,7 +896,7 @@ en:
           revert: "Revert protocol"
           revert_title: "Revert the protocol to the repository version. This will discard any local changes."
           save_to_repository: "Save to protocol repository"
-          save_a_copy_to_repository: "Save a copy to protocol repository"
+          save_a_copy_to_repository: "Save a copy to repository"
           save_to_repository_title: "Copy this protocol to repository"
           update_self: "Update from repository"
           update_self_title: "Update this protocol with the version stored in the repository"


### PR DESCRIPTION
Jira ticket: [SCI-6963](https://biosistemika.atlassian.net/browse/SCI-6963)

### What was done
- i icon flyout buttons stay in the flyout
- Added linked text instead of a linked protocol name and some CSS fixes