### PR TITLE
Make devise session timeout configurable through env variable [SCI-7028]

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -202,7 +202,11 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  config.timeout_in = 3.hours
+  config.timeout_in = if ENV['SCINOTE_SESSION_TIMEOUTS_IN'].present?
+                        ENV['SCINOTE_SESSION_TIMEOUTS_IN'].to_i.seconds
+                      else
+                        3.hours
+                      end
 
   # If true, expires auth token on session timeout.
   # config.expire_auth_token_on_timeout = false


### PR DESCRIPTION
Jira ticket: [SCI-7028](https://biosistemika.atlassian.net/browse/SCI-7028)

### What was done
Make devise session timeout configurable through env variable