### PR TITLE
Fix export of protocols with empty step text fields [SCI-7126]

### DIFF
--- a/app/utilities/protocols_exporter_v2.rb
+++ b/app/utilities/protocols_exporter_v2.rb
@@ -91,7 +91,7 @@ module ProtocolsExporterV2
           "<!--[CDATA[  #{Nokogiri::HTML::DocumentFragment.parse(step_text.text)}  ]]-->"\
           "</contents>\n"
 
-    xml << get_tiny_mce_assets(step_text.text)
+    xml << get_tiny_mce_assets(step_text.text) if step_text.text.present?
 
     xml << "</stepText>\n"
   end


### PR DESCRIPTION
Jira ticket: [SCI-7126](https://biosistemika.atlassian.net/browse/SCI-7126)

### What was done
Fix export of protocols with empty step text fields