### PR TITLE
Fix sorting of results by newest/oldest (by updated_at) [SCI-7118]

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -52,7 +52,11 @@ class Comment < ApplicationRecord
   def self.mark_as_seen_by(user, commentable)
     # rubocop:disable Rails/SkipsModelValidations
     all.where('? = ANY (unseen_by)', user.id).update_all("unseen_by = array_remove(unseen_by, #{user.id.to_i}::bigint)")
-    commentable.touch
+
+    # Because we want the number of unseen comments to affect the cache of project
+    # and experiment lists, we need to set the updated_at of Project or Experiment.
+    commentable.touch if commentable.class.in? [Project, Experiment]
+
     # rubocop:enable Rails/SkipsModelValidations
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-7118](https://biosistemika.atlassian.net/browse/SCI-7118)

### What was done
Fix sorting of results by newest/oldest (by updated_at), by only including projects and experiments (which show the comment count in lists) in the cache-busting touch when using mark_as_seen for comments.