### PR TITLE
Fix underline in docx report generator [SCI-7161]

### DIFF
--- a/app/services/reports/html_to_word_converter.rb
+++ b/app/services/reports/html_to_word_converter.rb
@@ -33,6 +33,7 @@ module Reports
               color style[:color]
               bold style[:bold]
               italic style[:italic]
+              underline true
             end
           end
         elsif elem[:type] == 'image'
@@ -106,13 +107,8 @@ module Reports
           next
         end
 
-        if elem.name == 'sup'
-          elements.push(sup_element(elem))
-          next
-        end
-
-        if elem.name == 'sub'
-          elements.push(sub_element(elem))
+        if %w(sup sub).include?(elem.name)
+          elements.push(text_formatting_element(elem))
           next
         end
 
@@ -196,7 +192,7 @@ module Reports
       result[:style] = elem.name if elem.name.include? 'h'
       result[:bold] = true if elem.name == 'strong'
       result[:italic] = true if elem.name == 'em'
-      style_keys = %w(text-align color)
+      style_keys = %w(text-align color text-decoration)
 
       if style
         style_keys.each do |key|
@@ -204,10 +200,13 @@ module Reports
           next unless style_el
 
           value = style_el.split(':')[1].strip if style_el
+
           if key == 'text-align'
             result[:align] = value.to_sym
           elsif key == 'color' && Reports::Utils.calculate_color_hsp(value) < 190
             result[:color] = value.delete('#')
+          elsif key == 'text-decoration' && value == 'underline'
+            result[:underline] = true
           end
         end
       end
@@ -268,12 +267,8 @@ module Reports
       { type: 'table', data: rows }
     end
 
-    def sup_element(element)
-      { type: 'sup', value: element.text }
-    end
-
-    def sub_element(element)
-      { type: 'sub', value: element.text }
+    def text_formatting_element(element)
+      { type: element.name, value: element.text }
     end
   end
 end

--- a/app/services/reports/html_to_word_converter.rb
+++ b/app/services/reports/html_to_word_converter.rb
@@ -33,7 +33,6 @@ module Reports
               color style[:color]
               bold style[:bold]
               italic style[:italic]
-              underline true
             end
           end
         elsif elem[:type] == 'image'


### PR DESCRIPTION
Jira ticket: [SCI-7161](https://biosistemika.atlassian.net/browse/SCI-7161)

### What was done
_FIxed underline option in docx generator, tried fixing strikethrough too, but the gem that is used (caracal) only supports standard set of effects, which does not include strikethrough_


