### PR TITLE
Fix docx table generator if metadata is unknown [SCI-8165]

### DIFF
--- a/app/services/reports/docx/draw_result_table.rb
+++ b/app/services/reports/docx/draw_result_table.rb
@@ -8,10 +8,12 @@ module Reports::Docx::DrawResultTable
     obj = self
     @docx.p
     @docx.table JSON.parse(table.contents_utf_8)['data'], border_size: Constants::REPORT_DOCX_TABLE_BORDER_SIZE do
-      JSON.parse(table.metadata)['cells'].each do |cell|
-        next unless cell.present? && cell['row'].present? && cell['col'].present? && cell['className'].present?
+      if table.metadata.present?
+        JSON.parse(table.metadata)['cells']&.each do |cell|
+          next unless cell.present? && cell['row'].present? && cell['col'].present? && cell['className'].present?
 
-        cell_style rows.dig(cell['row'].to_i, cell['col'].to_i), align: obj.table_cell_alignment(cell['className'])
+          cell_style rows.dig(cell['row'].to_i, cell['col'].to_i), align: obj.table_cell_alignment(cell['className'])
+        end
       end
     end
     @docx.p do


### PR DESCRIPTION
Jira ticket: [SCI-8165](https://scinote.atlassian.net/browse/SCI-8165)

### What was done
Fix docx table generator if metadata is nil 

[SCI-8165]: https://scinote.atlassian.net/browse/SCI-8165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ