### PR TITLE
Revert back to pre 7.2 ActiveStorage variant behaviour [SCI-11841]

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -81,6 +81,9 @@ module Scinote
 
     config.x.export_all_limit_24h = (ENV['EXPORT_ALL_LIMIT_24_HOURS'] || 3).to_i
 
+    # Fallback to old variant behaviour (pre 7.2)
+    config.active_storage.track_variants = false
+
     # SciNote Core Application version
     VERSION = File.read(Rails.root.join('VERSION')).strip.freeze
 


### PR DESCRIPTION
Jira ticket: [SCI-11841](https://scinote.atlassian.net/browse/SCI-11841)

### What was done
Revert back to pre 7.2 ActiveStorage variant behaviour

[SCI-11841]: https://scinote.atlassian.net/browse/SCI-11841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ