### PR TITLE
Fix repository user manage permissions for team owner [SCI-12245]

### DIFF
--- a/app/permissions/repository.rb
+++ b/app/permissions/repository.rb
@@ -131,7 +131,8 @@ Canaid::Permissions.register_for(Repository) do
   end
 
   can :manage_repository_users do |user, repository|
-    repository.can_manage_shared?(user) ||
+    repository.team.permission_granted?(user, TeamPermissions::MANAGE) ||
+      repository.can_manage_shared?(user) ||
       repository.permission_granted?(user, RepositoryPermissions::USERS_MANAGE)
   end
 end


### PR DESCRIPTION
Jira ticket: [SCI-12245](https://scinote.atlassian.net/browse/SCI-12245)

### What was done
Fix repository user manage permissions for team owner

[SCI-12245]: https://scinote.atlassian.net/browse/SCI-12245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ