### PR TITLE
Fix logic parenthesis in .can_manage_shared? [SCI-12271]

### DIFF
--- a/app/models/concerns/shareable.rb
+++ b/app/models/concerns/shareable.rb
@@ -50,8 +50,8 @@ module Shareable
   end
 
   def can_manage_shared?(user)
-    globally_shared? ||
-      (shared_with?(user.current_team) && user.current_team.permission_granted?(user, TeamPermissions::MANAGE))
+    (globally_shared? || shared_with?(user.current_team)) &&
+      user.current_team.permission_granted?(user, TeamPermissions::MANAGE)
   end
 
   def shareable_write?


### PR DESCRIPTION
Jira ticket: [SCI-12271](https://scinote.atlassian.net/browse/SCI-12271)

### What was done
Fix logic parenthesis in .can_manage_shared?

[SCI-12271]: https://scinote.atlassian.net/browse/SCI-12271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ