### PR TITLE
Fix group assignment url for non-manage roles on repository [SCI-12271]

### DIFF
--- a/app/serializers/lists/repository_serializer.rb
+++ b/app/serializers/lists/repository_serializer.rb
@@ -58,7 +58,8 @@ module Lists
         show_access: access_permissions_repository_path(object),
         share: team_shared_objects_path(current_user.current_team, object_id: object.id, object_type: 'Repository'),
         user_roles: user_roles_access_permissions_repository_path(object),
-        user_group_members: users_users_settings_team_user_groups_path(team_id: current_user.current_team_id)
+        user_group_members: users_users_settings_team_user_groups_path(team_id: current_user.current_team_id),
+        show_user_group_assignments_access: show_user_group_assignments_access_permissions_repository_path(object)
       }
 
       urls[:show] = repository_path(object) if can_read?
@@ -68,7 +69,6 @@ module Lists
         urls[:new_access] = new_access_permissions_repository_path(id: object.id)
         urls[:create_access] = access_permissions_repositories_path(id: object.id)
         urls[:unassigned_user_groups] = unassigned_user_groups_access_permissions_repository_path(id: object.id)
-        urls[:show_user_group_assignments_access] = show_user_group_assignments_access_permissions_repository_path(object)
       end
 
       urls


### PR DESCRIPTION
Jira ticket: [SCI-12271](https://scinote.atlassian.net/browse/SCI-12271)

### What was done
Fix group assignment url for non-manage roles on repository

[SCI-12271]: https://scinote.atlassian.net/browse/SCI-12271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ