### PR TITLE
Fix displaying no search results banner when label templates are disabled [SCI-12375]

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -46,7 +46,7 @@ class SearchController < ApplicationController
           search_by_name({ in_repository: true })
           @records = @records.preload(:team, :added_by)
         when 'label_templates'
-          return render json: [], meta: { disabled: true }, status: :ok unless LabelTemplate.enabled?
+          return render json: [], meta: { disabled: true, total: 0 } unless LabelTemplate.enabled?
 
           @model = LabelTemplate
           search_by_name


### PR DESCRIPTION
Jira ticket: [SCI-12375](https://scinote.atlassian.net/browse/SCI-12375)

### What was done
Fix displaying no search results banner when label templates are disabled

[SCI-12375]: https://scinote.atlassian.net/browse/SCI-12375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ