### PR TITLE
Fix parameterization of search named query interpolation parameters [SCI-12413]

### DIFF
--- a/app/models/concerns/searchable_model.rb
+++ b/app/models/concerns/searchable_model.rb
@@ -121,7 +121,7 @@ module SearchableModel
           like = exact_match ? '~' : 'ILIKE'
 
           where_str = (attributes.map do |attribute|
-            attribute_key = attribute.to_s.tr('.', '_')
+            attribute_key = attribute.to_s.parameterize(separator: '_')
 
             if attribute == :children
               "\"#{table_name}\".\"id\" IN (#{where_children_attributes_like(token[:value]).select(:id).to_sql}) OR "
@@ -141,7 +141,7 @@ module SearchableModel
           attributes.each do |attribute|
             next if attribute == :children
 
-            query_params[:"#{attribute.to_s.tr('.', '_')}_#{index}_query"] =
+            query_params[:"#{attribute.to_s.parameterize(separator: '_')}_#{index}_query"] =
               if SEARCH_DATA_VECTOR_ATTRIBUTES.include?(attribute) && !exact_match
                 token[:value].split(/\s+/).map! { |t| "#{t}:*" }
               else


### PR DESCRIPTION
Jira ticket: [SCI-12413](https://scinote.atlassian.net/browse/SCI-12413)

### What was done
The named parameters would not be properly parameterized for the special ID expression column (PREFIXED_ID_SQL):
 ('TA' || my_modules.id) =>   ('TA' || my_modules_id)_0_query
 
 This fix now properly parameterizes this expression column into: :ta_my_modules_id_0_query.

[SCI-12413]: https://scinote.atlassian.net/browse/SCI-12413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ