### PR TITLE
Include archived step/result elements in global search queries [SCI-12964]

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -17,7 +17,7 @@ class CommentsController < ApplicationController
     object_url = nil
     case @commentable
     when Step
-      object_name = "#{@commentable.position + 1} #{@commentable.name}"
+      object_name = @commentable.position ? "#{@commentable.position + 1} #{@commentable.name}" : @commentable.name
       object_url = link_to(t('comments.step_url'), "#stepContainer#{@commentable.id}", class: 'scroll-page-with-anchor')
     else
       object_name = @commentable.name

--- a/app/models/protocol.rb
+++ b/app/models/protocol.rb
@@ -167,39 +167,80 @@ class Protocol < ApplicationRecord
 
     protocols = protocols.with(readable_protocols: readable_protocols)
                          .joins('INNER JOIN "readable_protocols" ON "readable_protocols"."id" = "protocols"."id"')
-
+    options[:include_archived] = include_archived
     protocols.where_attributes_like_boolean(SEARCHABLE_ATTRIBUTES, query, options)
   end
 
   def self.where_children_attributes_like(query, options = {})
-    unscoped_readable_protocols = unscoped.joins('INNER JOIN "readable_protocols" ON "readable_protocols"."id" = "protocols"."id"').select(:id)
-    sql = "#{unscoped_readable_protocols.joins(:steps).where_attributes_like(Step::SEARCHABLE_IN_PROTOCOL_ATTRIBUTES , query).to_sql}
-      UNION ALL
-      #{unscoped_readable_protocols.joins(steps: :step_texts).where_attributes_like(StepText::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      UNION ALL
-      #{unscoped_readable_protocols.joins(steps: { step_tables: :table }).where_attributes_like(Table::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      UNION ALL
-      #{unscoped_readable_protocols.joins(steps: :checklists).where_attributes_like(Checklist::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      UNION ALL
-      #{unscoped_readable_protocols.joins(steps: { checklists: :checklist_items }).where_attributes_like(ChecklistItem::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      UNION ALL
-      #{unscoped_readable_protocols.joins(steps: :step_comments).where_attributes_like(StepComment::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      UNION ALL
-      #{unscoped_readable_protocols.joins(:results).where_attributes_like(ResultTemplate::SEARCHABLE_IN_PROTOCOL_ATTRIBUTES, query).to_sql}
-      UNION ALL
-      #{unscoped_readable_protocols.joins(results: :result_texts).where_attributes_like(ResultText::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      UNION ALL
-      #{unscoped_readable_protocols.joins(results: { result_tables: :table }).where_attributes_like(Table::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      "
-    unless options[:in_repository]
-      sql += "UNION ALL
-        #{unscoped_readable_protocols.joins(steps: { form_responses: :form_field_values }).where_attributes_like(FormFieldValue::SEARCHABLE_ATTRIBUTES, query).to_sql}
+    if options[:include_archived] || options[:in_repository]
+      unscoped_readable_protocols = unscoped.joins('INNER JOIN "readable_protocols" ON "readable_protocols"."id" = "protocols"."id"').select(:id)
+      sql = "#{unscoped_readable_protocols.joins(:steps).where_attributes_like(Step::SEARCHABLE_IN_PROTOCOL_ATTRIBUTES, query).to_sql}
         UNION ALL
-        #{unscoped_readable_protocols.joins(steps: { form_responses: :form }).where_attributes_like(Form::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        #{unscoped_readable_protocols.joins(steps: :step_texts).where_attributes_like(StepText::SEARCHABLE_ATTRIBUTES, query).to_sql}
         UNION ALL
-        #{unscoped_readable_protocols.joins(steps: { form_responses: { form: :form_fields } }).where_attributes_like(FormField::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        #{unscoped_readable_protocols.joins(steps: { step_tables: :table }).where_attributes_like(Table::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: :checklists).where_attributes_like(Checklist::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: { checklists: :checklist_items }).where_attributes_like(ChecklistItem::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: :step_comments).where_attributes_like(StepComment::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(:results).where_attributes_like(ResultTemplate::SEARCHABLE_IN_PROTOCOL_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(results: :result_texts).where_attributes_like(ResultText::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(results: { result_tables: :table }).where_attributes_like(Table::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        "
+
+      unless options[:in_repository]
+        sql += "UNION ALL
+          #{unscoped_readable_protocols.joins(steps: { form_responses: :form_field_values }).where_attributes_like(FormFieldValue::SEARCHABLE_ATTRIBUTES, query).to_sql}
+          UNION ALL
+          #{unscoped_readable_protocols.joins(steps: { form_responses: :form }).where_attributes_like(Form::SEARCHABLE_ATTRIBUTES, query).to_sql}
+          UNION ALL
+          #{unscoped_readable_protocols.joins(steps: { form_responses: { form: :form_fields } }).where_attributes_like(FormField::SEARCHABLE_ATTRIBUTES, query).to_sql}
+          "
+      end
+    else
+      unscoped_readable_protocols = unscoped.joins('INNER JOIN "readable_protocols" ON "readable_protocols"."id" = "protocols"."id"')
+                                            .joins(:steps)
+                                            .where(steps: { archived: false })
+                                            .select(:id)
+      sql = "#{unscoped_readable_protocols.where_attributes_like(Step::SEARCHABLE_IN_PROTOCOL_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: { step_texts: :step_orderable_element })
+                                     .where(step_orderable_element: { archived: false })
+                                     .where_attributes_like(StepText::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: { step_tables: %i(table step_orderable_element) })
+                                     .where(step_orderable_element: { archived: false })
+                                     .where_attributes_like(Table::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: { checklists: :step_orderable_element })
+                                     .where(step_orderable_element: { archived: false })
+                                     .where_attributes_like(Checklist::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: { checklists: %i(checklist_items step_orderable_element) })
+                                     .where(step_orderable_element: { archived: false })
+                                     .where_attributes_like(ChecklistItem::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: :step_comments).where_attributes_like(StepComment::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: { form_responses: %i(form_field_values step_orderable_element) })
+                                     .where(step_orderable_element: { archived: false })
+                                     .where_attributes_like(FormFieldValue::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: { form_responses: %i(form step_orderable_element) })
+                                     .where(step_orderable_element: { archived: false })
+                                     .where_attributes_like(Form::SEARCHABLE_ATTRIBUTES, query).to_sql}
+        UNION ALL
+        #{unscoped_readable_protocols.joins(steps: { form_responses: [:step_orderable_element, { form: :form_fields }] })
+                                     .where(step_orderable_element: { archived: false })
+                                     .where_attributes_like(FormField::SEARCHABLE_ATTRIBUTES, query).to_sql}
         "
     end
+
     unscoped.from("(#{sql}) AS protocols", :protocols)
   end
 

--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -35,20 +35,30 @@ class Result < ResultBase
     results = results.with(readable_results: readable_results)
                      .joins('INNER JOIN "readable_results" ON "readable_results"."id" = "results"."id"')
 
-    results.where_attributes_like_boolean(SEARCHABLE_ATTRIBUTES, query)
+    results.where_attributes_like_boolean(SEARCHABLE_ATTRIBUTES, query, { include_archived: include_archived })
   end
 
-  def self.where_children_attributes_like(query, _options = {})
+  def self.where_children_attributes_like(query, options = {})
     unscoped_readable_results = unscoped.joins('INNER JOIN "readable_results" ON "readable_results"."id" = "results"."id"').select(:id, :type)
-    unscoped.from(
-      "(#{unscoped_readable_results.joins(:result_texts).where_attributes_like(ResultText::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      UNION
-      #{unscoped_readable_results.joins(result_tables: :table).where_attributes_like(Table::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      UNION
-      #{unscoped_readable_results.joins(:result_comments).where_attributes_like(ResultComment::SEARCHABLE_ATTRIBUTES, query).to_sql}
-      ) AS results",
-      :results
-    )
+    if options[:include_archived]
+      text_sql = unscoped_readable_results.joins(:result_texts).where_attributes_like(ResultText::SEARCHABLE_ATTRIBUTES, query).to_sql
+
+      table_sql = unscoped_readable_results.joins(result_tables: :table).where_attributes_like(Table::SEARCHABLE_ATTRIBUTES, query).to_sql
+    else
+      text_sql = unscoped_readable_results.joins(result_texts: :result_orderable_element)
+                                          .where(result_orderable_element: { archived: false })
+                                          .where_attributes_like(ResultText::SEARCHABLE_ATTRIBUTES, query)
+                                          .to_sql
+
+      table_sql = unscoped_readable_results.joins(result_tables: %i(table result_orderable_element))
+                                           .where(result_orderable_element: { archived: false })
+                                           .where_attributes_like(Table::SEARCHABLE_ATTRIBUTES, query)
+                                           .to_sql
+    end
+
+    comment_sql = unscoped_readable_results.joins(:result_comments).where_attributes_like(ResultComment::SEARCHABLE_ATTRIBUTES, query).to_sql
+
+    unscoped.from("(#{text_sql} UNION #{table_sql} UNION #{comment_sql}) AS results", :results)
   end
 
   def self.readable_by_user(user, teams)


### PR DESCRIPTION
Jira ticket: [SCI-12964](https://scinote.atlassian.net/browse/SCI-12964)

### What was done
Include archived step/result elements in global search queries

[SCI-12964]: https://scinote.atlassian.net/browse/SCI-12964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ