### PR TITLE
Improve file preview generation error handling in projects export jobs [SCI-12765]

### DIFF
--- a/app/jobs/team_zip_export_job.rb
+++ b/app/jobs/team_zip_export_job.rb
@@ -208,7 +208,7 @@ class TeamZipExportJob < ZipExportJob
           file_name = preview.blob.filename.to_s
           file_data = preview.download
         end
-      rescue ActiveStorage::FileNotFoundError => e
+      rescue StandardError => e
         Rails.logger.error(e.message)
         Rails.logger.error(e.backtrace.join("\n"))
         return


### PR DESCRIPTION
Jira ticket: [SCI-12765](https://scinote.atlassian.net/browse/SCI-12765)

### What was done
Improve file preview generation error handling in projects export jobs

[SCI-12765]: https://scinote.atlassian.net/browse/SCI-12765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ