### PR TITLE
Don't show 'create with AI' option in protocol template [SCI-13089]

### DIFF
--- a/app/javascript/vue/protocol/protocolOptions.vue
+++ b/app/javascript/vue/protocol/protocolOptions.vue
@@ -28,7 +28,7 @@
             <span>{{ i18n.t("my_modules.protocol.options_dropdown.load_from_repo") }}</span>
           </a>
         </li>
-        <li v-if="protocol.attributes.urls.add_protocol_steps_url">
+        <li v-if="protocol.attributes.urls.add_protocol_steps_url && !inRepository">
           <a class="!px-3 !py-2.5 hover:!bg-sn-super-light-blue !text-sn-blue"
             data-turbolinks="false"
             @click.prevent="createWithAi()"


### PR DESCRIPTION
Jira ticket: [SCI-13089](https://scinote.atlassian.net/browse/SCI-13089)

### What was done
Don't show 'create with AI' option in protocol template

[SCI-13089]: https://scinote.atlassian.net/browse/SCI-13089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ