### PR TITLE
Insert to pdf reports files with extension PDF [SCI-13099]

### DIFF
--- a/app/jobs/reports/pdf_job.rb
+++ b/app/jobs/reports/pdf_job.rb
@@ -180,7 +180,7 @@ module Reports
           results = my_module_element.my_module.results
           order_results_for_report(results, @report.settings.dig(:task, :result_order)).each do |result|
             result.assets.each do |asset|
-              next unless PREVIEW_EXTENSIONS.include?(asset.file.blob.filename.extension)
+              next unless PREVIEW_EXTENSIONS.include?(asset.file.blob.filename.extension.downcase)
 
               if !asset.file_pdf_preview.attached? || (asset.file.created_at > asset.file_pdf_preview.created_at)
                 PdfPreviewJob.perform_now(asset.id)


### PR DESCRIPTION
Jira ticket: [SCI-13099](https://scinote.atlassian.net/browse/SCI-13099)

### What was done
Insert to pdf reports files with extension PDF 

[SCI-13099]: https://scinote.atlassian.net/browse/SCI-13099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ