### PR TITLE
Update Dockerfile with dpkg-architecture lookup [SCI-13214]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update -qq && \
   wget -O $TIKA_PATH $TIKA_DIST_URL && \
   chmod +x $TIKA_PATH && \
   ln -s /usr/bin/yarnpkg /usr/bin/yarn && \
-  ln -s /usr/lib/x86_64-linux-gnu/libvips.so.42 /usr/lib/x86_64-linux-gnu/libvips.so && \
+  ln -s /usr/lib/$(dpkg-architecture -q DEB_HOST_MULTIARCH)/libvips.so.42 /usr/lib/$(dpkg-architecture -q DEB_HOST_MULTIARCH)/libvips.so && \
   rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/usr/share/nodejs/yarn/bin:$PATH


### PR DESCRIPTION
Jira ticket: [SCI-13214](https://scinote.atlassian.net/browse/SCI-13214)

### What was done
Update Dockerfile with dpkg-architecture lookup based on the CPU (ARM, x86)

[SCI-13214]: https://scinote.atlassian.net/browse/SCI-13214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ