### PR TITLE
Add initial implementation for csrf token refresh when reviving expiring session [SCI-13185]

### DIFF
--- a/app/assets/javascripts/session_end.js
+++ b/app/assets/javascripts/session_end.js
@@ -69,7 +69,24 @@
   }
 
   function reviveSession() {
-    $.post($('meta[name=\'revive-url\']').attr('content'));
+    $.post($('meta[name=\'revive-url\']').attr('content'), (data) => {
+      if (!data.csrf_token) {
+        return;
+      }
+
+      const metaTag = document.querySelector('meta[name="csrf-token"]');
+
+      if (metaTag) {
+        metaTag.setAttribute("content", data.csrf_token);
+      }
+
+      document
+        .querySelectorAll('input[type="hidden"][name="authenticity_token"]')
+        .forEach((input) => {
+          input.value = data.csrf_token;
+        });
+    });
+
     toggleDocumentTitle();
     window.localStorage.removeItem('sessionEnd');
     setSessionTimeout(initializeSessionCountdown, oneSecondTimeout);

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -45,7 +45,9 @@ class Users::SessionsController < Devise::SessionsController
     end
   end
 
-  def revive_session; end
+  def revive_session
+    render json: { csrf_token: form_authenticity_token }
+  end
 
   def two_factor_recovery
     unless session[:otp_user_id]


### PR DESCRIPTION
Jira ticket: [SCI-13185](https://scinote.atlassian.net/browse/SCI-13185)

### What was done
Add initial implementation for csrf token refresh when reviving expiring session 


[SCI-13185]: https://scinote.atlassian.net/browse/SCI-13185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ