### PR TITLE
Add a PoC for docx report generation using odt templates and odf-templates gem [SCI-13192]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'mime-types', '~> 3.4'
 gem 'nested_form_fields'
 gem 'nokogiri', '~> 1.19.1' # HTML/XML parser
 gem 'noticed'
+gem 'odf-report', git: 'https://github.com/scinote-eln/odf-report', branch: 'rich-text-improvements' # Build report from odt template
 gem 'oj'
 gem 'rails_autolink', '~> 1.1', '>= 1.1.6'
 gem 'rgl' # Graph framework for project diagram calculations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,16 @@ GIT
       mini_magick (~> 4.9)
 
 GIT
+  remote: https://github.com/scinote-eln/odf-report
+  revision: 122fa812bd9fb2ecc3c0842dd5a5e946f5a16251
+  branch: rich-text-improvements
+  specs:
+    odf-report (0.9.0)
+      mime-types
+      nokogiri (>= 1.12.0)
+      rubyzip (>= 1.3.0)
+
+GIT
   remote: https://github.com/scinote-eln/omniauth-okta
   revision: fc4d833532dec050a3c6296691d631b64de1ee19
   branch: org_auth_server_support

--- a/app/jobs/reports/docx_job.rb
+++ b/app/jobs/reports/docx_job.rb
@@ -20,8 +20,6 @@ module Reports
         Reports::Docx.new(report, docx, user: user, scinote_url: root_url).draw
         docx.save
         report.docx_file.attach(io: file, filename: 'report.docx')
-        report_path = Rails.application.routes.url_helpers
-                           .reports_path(team: report.team.id, preview_report_id: report.id, preview_type: :docx)
 
         DeliveryNotification.send_notifications(
           {

--- a/app/jobs/reports/docx_template_job.rb
+++ b/app/jobs/reports/docx_template_job.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Reports
+  class DocxTemplateJob < DocxJob
+    def perform(report_id, user_id:, root_url:)
+      report = Report.find(report_id)
+      user = User.find(user_id)
+      report_odt_file = Tempfile.new(['report', '.odt'])
+      report_docx_file = nil
+      begin
+        I18n.backend.date_format = user.settings[:date_format]
+
+        odt_report = nil
+
+        report.odt_template_file.open do |odt_template_file|
+          odt_report = ODFReport::Report.new(
+              odt_template_file.path
+            ) do |r|
+              r.add_field(:id, report.id.to_s)
+              r.add_field(:created_by, report.created_by)
+              r.add_field(:created_at, report.created_at.strftime("%d/%m/%Y - %H:%M"))
+              r.add_text :notes, '<h1>Notes</h1>'
+              r.add_checklist(:form, [
+              { text: "Design approved", checked: true },
+              { text: "Code reviewed",   checked: false },
+              ["Array form", true],
+              "Bare string (unchecked)",
+            ])
+            end
+
+          odt_report.generate(report_odt_file.path)
+        end
+
+        report_docx_file = Reports::ConvertToDocxService.convert(report_odt_file)
+        report.docx_file.attach(io: report_docx_file, filename: 'report.docx')
+
+        DeliveryNotification.send_notifications(
+          {
+            title: I18n.t('projects.reports.index.generation.completed_docx_notification_title'),
+            subject_id: report_id,
+            subject_class: 'Report',
+            subject_name: report.name,
+            report_type: 'docx',
+            user_id: user.id
+          }
+        )
+
+        Reports::DocxPreviewJob.perform_now(report.id)
+        report.docx_ready!
+      ensure
+        I18n.backend.date_format = nil
+        report_odt_file.close
+        report_odt_file.unlink
+        File.delete(report_docx_file.path) if report_docx_file && File.file?(report_docx_file.path)
+      end
+    rescue StandardError => e
+      raise e if report.blank?
+
+      ActiveRecord::Base.no_touching do
+        report.docx_error!
+      end
+      Rails.logger.error("Couldn't generate DOCX for Report with id: #{report.id}. Error:\n #{e.message}")
+      raise e
+    end
+  end
+end

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -17,6 +17,7 @@ class Report < ApplicationRecord
   # ActiveStorage configuration
   has_one_attached :pdf_file
   has_one_attached :docx_file
+  has_one_attached :odt_template_file
   has_one_attached :docx_preview_file
 
   auto_strip_attributes :name, :description, nullify: false

--- a/app/services/reports/convert_to_docx_service.rb
+++ b/app/services/reports/convert_to_docx_service.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Reports
+  class ConvertToDocxService
+    def self.convert(original_file)
+      out_dir = File.dirname(original_file.path)
+      docx_file_name = "#{File.basename(original_file.path, '.*')}.docx"
+      Rails.logger.info "Starting docx conversion for file #{original_file.path}..."
+
+      libreoffice_path = ENV['LIBREOFFICE_PATH'] || 'soffice'
+
+      success = system(
+        'timeout',
+        Constants::PREVIEW_TIMEOUT_SECONDS.to_s,
+        libreoffice_path,
+        '--headless',
+        '--invisible',
+        '--convert-to',
+        'docx', '--outdir',
+        out_dir, original_file.path
+      )
+      unless success && File.file?(File.join(out_dir, docx_file_name))
+        raise StandardError, "There was an error generating docx for file #{original_file.path}!"
+      end
+      Rails.logger.info("Finished docx conversion for file #{original_file.path}.")
+      File.open(File.join(out_dir, docx_file_name))
+    end
+  end
+end

--- a/config/initializers/report_templates.rb
+++ b/config/initializers/report_templates.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+ODFReport.delimiters = :curly
+
 Dir.chdir(Rails.root.join('app/views/reports/templates')) do
   templates = Dir.glob('*').select { |entry| File.directory?(entry) }
   templates.each do |template|


### PR DESCRIPTION
Jira ticket: [SCI-13192](https://scinote.atlassian.net/browse/SCI-13192)

### What was done
Add a PoC for docx report generation using odt templates and odf-templates gem

you would need to manually attach a ODT template file to a specific report

[SCI-13192]: https://scinote.atlassian.net/browse/SCI-13192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ