### PR TITLE
Update gemfile.lock for odf-report version [SCI-13386]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,7 +26,7 @@ GIT
 
 GIT
   remote: https://github.com/scinote-eln/odf-report
-  revision: f7bbe6a98407fbe5d6e9ad7be134200a05dc0b8f
+  revision: ab0d83f5158a93d8ac056023779940093f188cd2
   branch: rich-text-improvements
   specs:
     odf-report (0.9.0)


### PR DESCRIPTION
Jira ticket: [SCI-13386](https://scinote.atlassian.net/browse/SCI-13386)

### What was done
Update gemfile.lock for odf-report version


[SCI-13386]: https://scinote.atlassian.net/browse/SCI-13386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ