### PR TITLE
Move active element methods to ResultBase [SCI-13398]

### DIFF
--- a/app/models/result.rb
+++ b/app/models/result.rb
@@ -80,17 +80,6 @@ class Result < ResultBase
     joins(my_module: { experiment: :project }).where(my_module: { experiments: { projects: { team: teams } } })
   end
 
-  def active_elements
-    result_texts.active + tables.active
-  end
-
-  def active_elements_ordered
-    (
-      result_texts.joins(:result_orderable_element).active.select('result_texts.*, result_orderable_elements.position as position') +
-      tables.joins(result_table: :result_orderable_element).active.select('tables.*, result_orderable_elements.position as position')
-    ).sort_by(&:position)
-  end
-
   def archived_elements
     result_texts.archived + tables.archived
   end

--- a/app/models/result_base.rb
+++ b/app/models/result_base.rb
@@ -37,6 +37,17 @@ class ResultBase < ApplicationRecord
     (position.to_f / per_page).ceil
   end
 
+  def active_elements
+    result_texts.active + tables.active
+  end
+
+  def active_elements_ordered
+    (
+      result_texts.joins(:result_orderable_element).active.select('result_texts.*, result_orderable_elements.position as position') +
+      tables.joins(result_table: :result_orderable_element).active.select('tables.*, result_orderable_elements.position as position')
+    ).sort_by(&:position)
+  end
+
   def duplicate(object, user, result_name: nil)
     ActiveRecord::Base.transaction do
       target_object = if object.is_a?(Protocol) && object.in_module?


### PR DESCRIPTION
Jira ticket: [SCI-13398](https://scinote.atlassian.net/browse/SCI-13398)

### What was done
Move active element methods to ResultBase

Fixes moving elements between result templates

[SCI-13398]: https://scinote.atlassian.net/browse/SCI-13398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ